### PR TITLE
fix: use platform dependent path for `join`, `resolve`, and `parse`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,9 +35,8 @@ export const dirname: typeof path.dirname = function (p) {
 }
 
 // resolve
-// TODO: Find a way to use path.posix for consistant behavior
 export const resolve: typeof path.resolve = function (...args) {
-  return path.resolve.apply(path.resolve, args.map(arg => normalizeWindowsPath(arg)))
+  return normalizeWindowsPath(path.win32.resolve(...args))
 }
 
 // format
@@ -52,12 +51,12 @@ export const basename: typeof path.basename = function (p, ext) {
 
 // parse
 export const parse: typeof path.parse = function (p) {
-  return path.posix.parse(normalizeWindowsPath(p))
+  return path.win32.parse(normalizeWindowsPath(p))
 }
 
 // toNamespacedPath
 export const toNamespacedPath: typeof path.toNamespacedPath = function (p) {
-  return p
+  return normalizeWindowsPath(p)
 }
 
 // isAbsolute

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,8 +20,9 @@ export const normalize: typeof path.normalize = function (p) {
 }
 
 // join
+// TODO
 export const join: typeof path.join = function (...args) {
-  return normalizeWindowsPath(path.win32.join(...args))
+  return normalizeWindowsPath(path.join(...args))
 }
 
 // relative
@@ -35,8 +36,9 @@ export const dirname: typeof path.dirname = function (p) {
 }
 
 // resolve
+// TODO
 export const resolve: typeof path.resolve = function (...args) {
-  return normalizeWindowsPath(path.win32.resolve(...args))
+  return normalizeWindowsPath(path.resolve(...args))
 }
 
 // format
@@ -50,8 +52,9 @@ export const basename: typeof path.basename = function (p, ext) {
 }
 
 // parse
+// TODO
 export const parse: typeof path.parse = function (p) {
-  return path.win32.parse(normalizeWindowsPath(p))
+  return path.parse(normalizeWindowsPath(p))
 }
 
 // toNamespacedPath

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export const normalize: typeof path.normalize = function (p) {
 
 // join
 export const join: typeof path.join = function (...args) {
-  return path.posix.join.apply(path.posix.join, args.map(arg => normalizeWindowsPath(arg)))
+  return normalizeWindowsPath(path.win32.join(...args))
 }
 
 // relative

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,8 +58,10 @@ export const parse: typeof path.parse = function (p) {
 }
 
 // toNamespacedPath
+// TODO
 export const toNamespacedPath: typeof path.toNamespacedPath = function (p) {
-  return normalizeWindowsPath(p)
+  return p
+  // return normalizeWindowsPath(p)
 }
 
 // isAbsolute


### PR DESCRIPTION
This takes advantage of the fact that win32 handles both `\` and `/` as valid separators and therefore can operate safely on a posix path.

1. resolves #2 by using `path.win32` (resolve)
1. handles unc paths by using `path.win32` (join)
1. resolves a parse issue where the drive letter was being stripped on windows
1. normalizes `toNamespacedPath` as well, for consistency

**An observation**: this entire library works (passes tests) in reverse using `path.win32` and normalising the result (as with 1 & 2 above)

With this PR merged, #3 should be passing.