### PR TITLE
fix: replace double-slashes in `join` calls

### DIFF
--- a/src/path.ts
+++ b/src/path.ts
@@ -70,7 +70,7 @@ export const join: typeof path.join = function (...args) {
     return '.'
   }
 
-  return normalize(joined)
+  return normalize(joined.replace(/\/\/+/g, '/'))
 }
 
 // resolve

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -79,6 +79,8 @@ runTest('format', format, [
 ])
 
 runTest('join', join, [
+  ['/', '/path', '/path'],
+  ['/test//', '//path', '/test/path'],
   ['some/nodejs/deep', '../path', 'some/nodejs/path'],
   ['./some/local/unix/', '../path', 'some/local/path'],
   ['./some\\current\\mixed', '..\\path', 'some/current/path'],
@@ -167,6 +169,7 @@ runTest('relative', relative, [
 
 runTest('resolve', resolve, [
   // POSIX
+  ['/', '/path', '/path'],
   ['/foo/bar', './baz', '/foo/bar/baz'],
   ['/foo/bar', '/tmp/file/', '/tmp/file'],
   ['wwwroot', 'static_files/png/', '../gif/image.gif', `${process.cwd()}/wwwroot/static_files/gif/image.gif`],


### PR DESCRIPTION
The tests added are all default Node behaviour.

resolves #16