### PR TITLE
fix: return `.` as dirname fallback for non-absolute paths

### DIFF
--- a/src/path.ts
+++ b/src/path.ts
@@ -201,7 +201,7 @@ export const relative: typeof path.relative = function (from, to) {
 
 // dirname
 export const dirname: typeof path.dirname = function (p) {
-  return normalizeWindowsPath(p).replace(/\/$/, '').split('/').slice(0, -1).join('/') || '/'
+  return normalizeWindowsPath(p).replace(/\/$/, '').split('/').slice(0, -1).join('/') || (isAbsolute(p) ? '/' : '.')
 }
 
 // format

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -44,6 +44,7 @@ runTest('basename', basename, [
 
 runTest('dirname', dirname, {
   // POSIX
+  'test.html': '.',
   '/temp/': '/',
   '/temp/myfile.html': '/temp',
   './myfile.html': '.',


### PR DESCRIPTION
resolves #18