### PR TITLE
fix: trim root folder `/` when calculating relative paths

### DIFF
--- a/src/path.ts
+++ b/src/path.ts
@@ -8,11 +8,11 @@ Check LICENSE file
 import type path from "node:path";
 
 import { normalizeWindowsPath } from "./_internal";
-import { _isAbsolutePath } from "./utils";
 
 const _UNC_REGEX = /^[/\\]{2}/;
 const _IS_ABSOLUTE_RE = /^[/\\](?![/\\])|^[/\\]{2}(?!\.)|^[A-Za-z]:[/\\]/;
 const _DRIVE_LETTER_RE = /^[A-Za-z]:$/;
+const _ROOT_FOLDER_RE = /^\/([A-Za-z]:)?$/;
 
 // Force POSIX contants
 export const sep = "/";
@@ -211,17 +211,9 @@ export const extname: typeof path.extname = function (p) {
 
 // relative
 export const relative: typeof path.relative = function (from, to) {
-  const resolvedFrom = resolve(from);
-  const _from = resolvedFrom.split("/");
-  const resolvedTo = resolve(to);
-  const _to = resolvedTo.split("/");
+  const _from = resolve(from).replace(_ROOT_FOLDER_RE, '$1').split("/");
+  const _to = resolve(to).replace(_ROOT_FOLDER_RE, '$1').split("/");
 
-  if (_isAbsolutePath(resolvedFrom)) {
-    _from.shift();
-  }
-  if (_isAbsolutePath(resolvedTo)) {
-    _to.shift();
-  }
   const _fromCopy = [..._from];
   for (const segment of _fromCopy) {
     if (_to[0] !== segment) {

--- a/src/path.ts
+++ b/src/path.ts
@@ -211,12 +211,15 @@ export const extname: typeof path.extname = function (p) {
 
 // relative
 export const relative: typeof path.relative = function (from, to) {
-  const _from = resolve(from).split("/");
-  const _to = resolve(to).split("/");
-  if (_isAbsolutePath(resolve(from))) {
+  const resolvedFrom = resolve(from);
+  const _from = resolvedFrom.split("/");
+  const resolvedTo = resolve(to);
+  const _to = resolvedTo.split("/");
+
+  if (_isAbsolutePath(resolvedFrom)) {
     _from.shift();
   }
-  if (_isAbsolutePath(resolve(to))) {
+  if (_isAbsolutePath(resolvedTo)) {
     _to.shift();
   }
   const _fromCopy = [..._from];

--- a/src/path.ts
+++ b/src/path.ts
@@ -5,6 +5,7 @@ Based on Node.js implementation:
 Check LICENSE file
 
 */
+
 import type path from "node:path";
 
 import { normalizeWindowsPath } from "./_internal";

--- a/src/path.ts
+++ b/src/path.ts
@@ -5,10 +5,10 @@ Based on Node.js implementation:
 Check LICENSE file
 
 */
-
 import type path from "node:path";
 
 import { normalizeWindowsPath } from "./_internal";
+import { _isRootPath } from "./utils";
 
 const _UNC_REGEX = /^[/\\]{2}/;
 const _IS_ABSOLUTE_RE = /^[/\\](?![/\\])|^[/\\]{2}(?!\.)|^[A-Za-z]:[/\\]/;
@@ -213,6 +213,12 @@ export const extname: typeof path.extname = function (p) {
 export const relative: typeof path.relative = function (from, to) {
   const _from = resolve(from).split("/");
   const _to = resolve(to).split("/");
+  if (_isRootPath(resolve(from))) {
+    _from.shift();
+  }
+  if (_isRootPath(resolve(to))) {
+    _to.shift();
+  }
   const _fromCopy = [..._from];
   for (const segment of _fromCopy) {
     if (_to[0] !== segment) {

--- a/src/path.ts
+++ b/src/path.ts
@@ -212,8 +212,8 @@ export const extname: typeof path.extname = function (p) {
 
 // relative
 export const relative: typeof path.relative = function (from, to) {
-  const _from = resolve(from).replace(_ROOT_FOLDER_RE, '$1').split("/");
-  const _to = resolve(to).replace(_ROOT_FOLDER_RE, '$1').split("/");
+  const _from = resolve(from).replace(_ROOT_FOLDER_RE, "$1").split("/");
+  const _to = resolve(to).replace(_ROOT_FOLDER_RE, "$1").split("/");
 
   const _fromCopy = [..._from];
   for (const segment of _fromCopy) {

--- a/src/path.ts
+++ b/src/path.ts
@@ -8,7 +8,7 @@ Check LICENSE file
 import type path from "node:path";
 
 import { normalizeWindowsPath } from "./_internal";
-import { _isRootPath } from "./utils";
+import { _isAbsolutePath } from "./utils";
 
 const _UNC_REGEX = /^[/\\]{2}/;
 const _IS_ABSOLUTE_RE = /^[/\\](?![/\\])|^[/\\]{2}(?!\.)|^[A-Za-z]:[/\\]/;
@@ -213,10 +213,10 @@ export const extname: typeof path.extname = function (p) {
 export const relative: typeof path.relative = function (from, to) {
   const _from = resolve(from).split("/");
   const _to = resolve(to).split("/");
-  if (_isRootPath(resolve(from))) {
+  if (_isAbsolutePath(resolve(from))) {
     _from.shift();
   }
-  if (_isRootPath(resolve(to))) {
+  if (_isAbsolutePath(resolve(to))) {
     _to.shift();
   }
   const _fromCopy = [..._from];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -62,6 +62,6 @@ function _compareAliases(a: string, b: string) {
   return b.split("/").length - a.split("/").length;
 }
 
-export function _isRootPath(path: string) {
-  return path === "/" || /^\/[a-z]:$/i.test(path);
+export function _isAbsolutePath(path: string) {
+  return path === "/" || /^\/[A-Za-z]:$/.test(path);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,7 +61,3 @@ export function filename(path: string) {
 function _compareAliases(a: string, b: string) {
   return b.split("/").length - a.split("/").length;
 }
-
-export function _isAbsolutePath(path: string) {
-  return path === "/" || /^\/[A-Za-z]:$/.test(path);
-}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,3 +61,7 @@ export function filename(path: string) {
 function _compareAliases(a: string, b: string) {
   return b.split("/").length - a.split("/").length;
 }
+
+export function _isRootPath(path: string) {
+  return path === "/" || /^\/[a-z]:$/i.test(path);
+}

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -235,6 +235,8 @@ it("parse", () => {
 runTest("relative", relative, [
   // POSIX
   ["/data/orandea/test/aaa", "/data/orandea/impl/bbb", "../../impl/bbb"],
+  ["/", "/foo/bar", "foo/bar"],
+  ["/foo", "/", ".."],
   [
     () => process.cwd(),
     "./dist/client/b-scroll.d.ts",
@@ -243,6 +245,8 @@ runTest("relative", relative, [
 
   // Windows
   ["C:\\orandea\\test\\aaa", "C:\\orandea\\impl\\bbb", "../../impl/bbb"],
+  ["C:\\", "C:\\foo\\bar", "foo/bar"],
+  ["C:\\foo", "C:\\", ".."],
   [
     () => process.cwd().replace(/\\/g, "/"),
     "./dist/client/b-scroll.d.ts",


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

resolves https://github.com/unjs/pathe/issues/126

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `split` method will generate redundant `""` when pass a root path

https://github.com/unjs/pathe/blob/055f50a6f1131f4e5c56cf259dd8816168fba329/src/path.ts#L213-L215

```ts
"/".split("/") //=> ["", ""] 
// But expected [""]
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
