### PR TITLE
fix: check `process.cwd` before calling it

### DIFF
--- a/src/path.ts
+++ b/src/path.ts
@@ -81,7 +81,7 @@ export const join: typeof path.join = function (...arguments_) {
 };
 
 function cwd() {
-  if (typeof process !== "undefined") {
+  if (typeof process !== "undefined" && typeof process.cwd === "function") {
     return process.cwd().replace(/\\/g, "/");
   }
   return "/";


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #148

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Some runtimes (like React Native) has a `process` global, but doesn't provide a `cwd` function. Instead of assuming the `cwd` function is available, just because the `process` global is, merging this PR will update the check to actually verify the `process.cwd` is a callable function before relying on it.

Resolves #148

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
