### PR TITLE
fix: uppercase windows drive letters

### DIFF
--- a/src/_internal.ts
+++ b/src/_internal.ts
@@ -1,7 +1,11 @@
+const _DRIVE_LETTER_START_RE = /^[A-Za-z]:\//;
+
 // Util to normalize windows paths to posix
 export function normalizeWindowsPath(input = "") {
-  if (!input || !input.includes("\\")) {
+  if (!input) {
     return input;
   }
-  return input.replace(/\\/g, "/");
+  return input
+    .replace(/\\/g, "/")
+    .replace(_DRIVE_LETTER_START_RE, (r) => r.toUpperCase());
 }

--- a/src/path.ts
+++ b/src/path.ts
@@ -13,7 +13,6 @@ import { normalizeWindowsPath } from "./_internal";
 const _UNC_REGEX = /^[/\\]{2}/;
 const _IS_ABSOLUTE_RE = /^[/\\](?![/\\])|^[/\\]{2}(?!\.)|^[A-Za-z]:[/\\]/;
 const _DRIVE_LETTER_RE = /^[A-Za-z]:$/;
-const _DRIVE_LETTER_START_RE = /^[A-Za-z]:\//;
 const _ROOT_FOLDER_RE = /^\/([A-Za-z]:)?$/;
 
 // Force POSIX contants
@@ -213,14 +212,9 @@ export const extname: typeof path.extname = function (p) {
 
 // relative
 export const relative: typeof path.relative = function (from, to) {
-  const _from = resolve(from)
-    .replace(_ROOT_FOLDER_RE, "$1")
-    .replace(_DRIVE_LETTER_START_RE, (r) => r.toUpperCase())
-    .split("/");
-  const _to = resolve(to)
-    .replace(_ROOT_FOLDER_RE, "$1")
-    .replace(_DRIVE_LETTER_START_RE, (r) => r.toUpperCase())
-    .split("/");
+  const _from = resolve(from).replace(_ROOT_FOLDER_RE, "$1").split("/");
+  const _to = resolve(to).replace(_ROOT_FOLDER_RE, "$1").split("/");
+
   const _fromCopy = [..._from];
   for (const segment of _fromCopy) {
     if (_to[0] !== segment) {

--- a/src/path.ts
+++ b/src/path.ts
@@ -13,6 +13,7 @@ import { normalizeWindowsPath } from "./_internal";
 const _UNC_REGEX = /^[/\\]{2}/;
 const _IS_ABSOLUTE_RE = /^[/\\](?![/\\])|^[/\\]{2}(?!\.)|^[A-Za-z]:[/\\]/;
 const _DRIVE_LETTER_RE = /^[A-Za-z]:$/;
+const _DRIVE_LETTER_START_RE = /^[A-Za-z]:\//;
 
 // Force POSIX contants
 export const sep = "/";
@@ -211,8 +212,8 @@ export const extname: typeof path.extname = function (p) {
 
 // relative
 export const relative: typeof path.relative = function (from, to) {
-  const _from = resolve(from).split("/");
-  const _to = resolve(to).split("/");
+  const _from = resolve(from).replace(_DRIVE_LETTER_START_RE, r => r.toUpperCase()).split("/");
+  const _to = resolve(to).replace(_DRIVE_LETTER_START_RE, r => r.toUpperCase()).split("/");
   const _fromCopy = [..._from];
   for (const segment of _fromCopy) {
     if (_to[0] !== segment) {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -243,6 +243,7 @@ runTest("relative", relative, [
 
   // Windows
   ["C:\\orandea\\test\\aaa", "C:\\orandea\\impl\\bbb", "../../impl/bbb"],
+  ["C:\\orandea\\test\\aaa", "c:\\orandea\\impl\\bbb", "../../impl/bbb"],
   [
     () => process.cwd().replace(/\\/g, "/"),
     "./dist/client/b-scroll.d.ts",

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -24,7 +24,7 @@ runTest("normalizeWindowsPath", normalizeWindowsPath, {
   "/foo/bar": "/foo/bar",
 
   // Windows
-  "c:\\foo\\bar": "c:/foo/bar",
+  "c:\\foo\\bar": "C:/foo/bar",
   "\\foo\\bar": "/foo/bar",
   ".\\foo\\bar": "./foo/bar",
 });
@@ -179,11 +179,11 @@ runTest("normalize", normalize, {
   "C:\\temp\\..": "C:/",
   "C:\\temp\\\\foo\\bar\\..\\": "C:/temp/foo/",
   "C:////temp\\\\/\\/\\/foo/bar": "C:/temp/foo/bar",
-  "c:/windows/nodejs/path": "c:/windows/nodejs/path",
-  "c:/windows/../nodejs/path": "c:/nodejs/path",
+  "c:/windows/nodejs/path": "C:/windows/nodejs/path",
+  "c:/windows/../nodejs/path": "C:/nodejs/path",
 
-  "c:\\windows\\nodejs\\path": "c:/windows/nodejs/path",
-  "c:\\windows\\..\\nodejs\\path": "c:/nodejs/path",
+  "c:\\windows\\nodejs\\path": "C:/windows/nodejs/path",
+  "c:\\windows\\..\\nodejs\\path": "C:/nodejs/path",
 
   "/windows\\unix/mixed": "/windows/unix/mixed",
   "\\windows//unix/mixed": "/windows/unix/mixed",


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/24621

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It was possible for a path segment to mismatch (`c:` !== `C:`) owing to drive letter case. This normalises it in `relative` before splitting into segments.

I can update this if https://github.com/unjs/pathe/pull/142 merges first.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
