### PR TITLE
fix(resolveAlias): handle aliases ending with trailing slash

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,8 @@
 import { join } from "./path";
 import { normalizeWindowsPath } from "./_internal";
 
-const pathSeparators = new Set(["/", "\\", undefined]);
+const SEPARATORS = ["/", "\\"];
+const pathSeparators = new Set([...SEPARATORS, undefined]);
 
 const normalizedAliasSymbol = Symbol.for("pathe:normalizedAlias");
 
@@ -43,7 +44,7 @@ export function resolveAlias(path: string, aliases: Record<string, string>) {
   const _path = normalizeWindowsPath(path);
   aliases = normalizeAliases(aliases);
   for (const alias in aliases) { 
-    if (_path.startsWith(alias) && pathSeparators.has(_path[alias[alias.length - 1] === '/' ? alias.length - 1 : alias.length])) {
+    if (_path.startsWith(alias) && pathSeparators.has(_path[SEPARATORS.includes(alias[alias.length - 1]) ? alias.length - 1 : alias.length])) {
       return join(aliases[alias], _path.slice(alias.length));
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,8 +42,8 @@ export function normalizeAliases(_aliases: Record<string, string>) {
 export function resolveAlias(path: string, aliases: Record<string, string>) {
   const _path = normalizeWindowsPath(path);
   aliases = normalizeAliases(aliases);
-  for (const alias in aliases) {
-    if (_path.startsWith(alias) && pathSeparators.has(_path[alias.length])) {
+  for (const alias in aliases) { 
+    if (_path.startsWith(alias) && pathSeparators.has(_path[alias[alias.length - 1] === '/' ? alias.length - 1 : alias.length])) {
       return join(aliases[alias], _path.slice(alias.length));
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,8 +43,17 @@ export function normalizeAliases(_aliases: Record<string, string>) {
 export function resolveAlias(path: string, aliases: Record<string, string>) {
   const _path = normalizeWindowsPath(path);
   aliases = normalizeAliases(aliases);
-  for (const alias in aliases) { 
-    if (_path.startsWith(alias) && pathSeparators.has(_path[SEPARATORS.includes(alias[alias.length - 1]) ? alias.length - 1 : alias.length])) {
+  for (const alias in aliases) {
+    if (
+      _path.startsWith(alias) &&
+      pathSeparators.has(
+        _path[
+          SEPARATORS.includes(alias[alias.length - 1])
+            ? alias.length - 1
+            : alias.length
+        ],
+      )
+    ) {
       return join(aliases[alias], _path.slice(alias.length));
     }
   }

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -9,7 +9,9 @@ describe("alias", () => {
     "@": "/root",
     bingpot: "@/bingpot/index.ts",
     test: "@bingpot/index.ts",
+    "~": "/src/index.js",
     "~/": "/src",
+    "~win": "C:/src/index.js",
     "~win/": "C:/src",
   };
   const aliases = normalizeAliases(_aliases);
@@ -22,7 +24,9 @@ describe("alias", () => {
         "@foo/bar/utils": "@foo/bar/dist/utils.mjs",
         "bingpot": "/root/bingpot/index.ts",
         "test": "@bingpot/index.ts",
+        "~": "/src/index.js",
         "~/": "/src",
+        "~win": "C:/src/index.js",
         "~win/": "C:/src",
       }
     `);

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -9,7 +9,7 @@ describe("alias", () => {
     "@": "/root",
     bingpot: "@/bingpot/index.ts",
     test: "@bingpot/index.ts",
-    "~~/": "C:/nitro"
+    "~~/": "C:/nitro",
   };
   const aliases = normalizeAliases(_aliases);
 
@@ -47,7 +47,7 @@ describe("alias", () => {
     });
     it('respect ending with /', () => {
       expect(resolveAlias("~~/user-module/mod", aliases)).toBe('C:/nitro/user-module/mod')
-    })
+    });
   });
 });
 

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -45,8 +45,10 @@ describe("alias", () => {
       expect(resolveAlias("foo/bar.js", aliases)).toBe("foo/bar.js");
       expect(resolveAlias("./bar.js", aliases)).toBe("./bar.js");
     });
-    it('respect ending with /', () => {
-      expect(resolveAlias("~~/user-module/mod", aliases)).toBe('C:/nitro/user-module/mod')
+    it("respect ending with /", () => {
+      expect(resolveAlias("~~/user-module/mod", aliases)).toBe(
+        "C:/nitro/user-module/mod",
+      );
     });
   });
 });

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -9,7 +9,8 @@ describe("alias", () => {
     "@": "/root",
     bingpot: "@/bingpot/index.ts",
     test: "@bingpot/index.ts",
-    "~~/": "C:/nitro",
+    "~/": "/src",
+    "~win/": "C:/src",
   };
   const aliases = normalizeAliases(_aliases);
 
@@ -21,7 +22,8 @@ describe("alias", () => {
         "@foo/bar/utils": "@foo/bar/dist/utils.mjs",
         "bingpot": "/root/bingpot/index.ts",
         "test": "@bingpot/index.ts",
-        "~~/": "C:/nitro",
+        "~/": "/src",
+        "~win/": "C:/src",
       }
     `);
   });
@@ -46,9 +48,8 @@ describe("alias", () => {
       expect(resolveAlias("./bar.js", aliases)).toBe("./bar.js");
     });
     it("respect ending with /", () => {
-      expect(resolveAlias("~~/user-module/mod", aliases)).toBe(
-        "C:/nitro/user-module/mod",
-      );
+      expect(resolveAlias("~/foo/bar", aliases)).toBe("/src/foo/bar");
+      expect(resolveAlias("~win/foo/bar", aliases)).toBe("C:/src/foo/bar");
     });
   });
 });

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -9,9 +9,9 @@ describe("alias", () => {
     "@": "/root",
     bingpot: "@/bingpot/index.ts",
     test: "@bingpot/index.ts",
-    "~": "/src/index.js",
+    "~": "/root/index.js",
     "~/": "/src",
-    "~win": "C:/src/index.js",
+    "~win": "C:/root/index.js",
     "~win/": "C:/src",
   };
   const aliases = normalizeAliases(_aliases);
@@ -24,9 +24,9 @@ describe("alias", () => {
         "@foo/bar/utils": "@foo/bar/dist/utils.mjs",
         "bingpot": "/root/bingpot/index.ts",
         "test": "@bingpot/index.ts",
-        "~": "/src/index.js",
+        "~": "/root/index.js",
         "~/": "/src",
-        "~win": "C:/src/index.js",
+        "~win": "C:/root/index.js",
         "~win/": "C:/src",
       }
     `);

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -9,6 +9,7 @@ describe("alias", () => {
     "@": "/root",
     bingpot: "@/bingpot/index.ts",
     test: "@bingpot/index.ts",
+    "~~/": "C:/nitro"
   };
   const aliases = normalizeAliases(_aliases);
 
@@ -20,6 +21,7 @@ describe("alias", () => {
         "@foo/bar/utils": "@foo/bar/dist/utils.mjs",
         "bingpot": "/root/bingpot/index.ts",
         "test": "@bingpot/index.ts",
+        "~~/": "C:/nitro",
       }
     `);
   });
@@ -43,6 +45,9 @@ describe("alias", () => {
       expect(resolveAlias("foo/bar.js", aliases)).toBe("foo/bar.js");
       expect(resolveAlias("./bar.js", aliases)).toBe("./bar.js");
     });
+    it('respect ending with /', () => {
+      expect(resolveAlias("~~/user-module/mod", aliases)).toBe('C:/nitro/user-module/mod')
+    })
   });
 });
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

resolve #154

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Hi :wave: this PR fix `resolveAlias`'s pathSeperator check by verifying if the alias ends with `/` or `\`

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
