### PR TITLE
fix(relative): handle different windows drive letters

### DIFF
--- a/src/path.ts
+++ b/src/path.ts
@@ -215,6 +215,11 @@ export const relative: typeof path.relative = function (from, to) {
   const _from = resolve(from).replace(_ROOT_FOLDER_RE, "$1").split("/");
   const _to = resolve(to).replace(_ROOT_FOLDER_RE, "$1").split("/");
 
+  // Different windows drive letters
+  if (_to[0][1] === ":" && _from[0][1] === ":" && _from[0] !== _to[0]) {
+    return _to.join("/");
+  }
+
   const _fromCopy = [..._from];
   for (const segment of _fromCopy) {
     if (_to[0] !== segment) {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -248,6 +248,7 @@ runTest("relative", relative, [
   ["C:\\orandea\\test\\aaa", "c:\\orandea\\impl\\bbb", "../../impl/bbb"],
   ["C:\\", "C:\\foo\\bar", "foo/bar"],
   ["C:\\foo", "C:\\", ".."],
+  ["C:\\foo", "d:\\bar", "D:/bar"],
   [
     () => process.cwd().replace(/\\/g, "/"),
     "./dist/client/b-scroll.d.ts",


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

resolves #143

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Small note: While current fix seemed reasonable to me, I am also amazed that `resolve` function internally makes paths like `/C:/` perhaps with some better fixes of route cause workaround like this and #142 wouldn't be required..

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
