### PR TITLE
feat(utils): add `reverseResolveAlias` util

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
-          cache: "pnpm"
+          node-version: "18"
+          cache: pnpm
       - run: pnpm install
       - run: pnpm lint
       - run: pnpm build

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Pathe exports some extra utilities that do not exist in standard Node.js [path m
 In order to use them, you can import from `pathe/utils` subpath:
 
 ```js
-import { filename, normalizeAliases, resolveAlias } from 'pathe/utils'
+import { filename, normalizeAliases, resolveAlias, reverseResolveAlias } from 'pathe/utils'
 ```
 
 ## License

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,6 +57,28 @@ export function resolveAlias(path: string, aliases: Record<string, string>) {
   return _path;
 }
 
+export function reverseResolveAlias(
+  path: string,
+  aliases: Record<string, string>,
+) {
+  const _path = normalizeWindowsPath(path);
+  aliases = normalizeAliases(aliases);
+
+  for (const [to, alias] of Object.entries(aliases).reverse()) {
+    if (!_path.startsWith(alias)) {
+      continue;
+    }
+
+    // Strip trailing slash from alias for check
+    const _alias = hasTrailingSlash(alias) ? alias.slice(0, -1) : alias;
+
+    if (hasTrailingSlash(_path[_alias.length])) {
+      return join(to, _path.slice(alias.length));
+    }
+  }
+  return _path;
+}
+
 const FILENAME_RE = /(^|[/\\])([^/\\]+?)(?=(\.[^.]+)?$)/;
 
 export function filename(path: string) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,14 +77,12 @@ export function resolveAlias(path: string, aliases: Record<string, string>) {
 /**
  * Resolves a path string to its possible alias.
  *
- * Returns an array of possible alias resolutions, sorted by specificity (longest first).
- *
- * Returns `undefined` if no alias is found.
+ * Returns an array of possible alias resolutions (could be empty), sorted by specificity (longest first).
  */
 export function reverseResolveAlias(
   path: string,
   aliases: Record<string, string>,
-): undefined | string[] {
+): string[] {
   const _path = normalizeWindowsPath(path);
   aliases = normalizeAliases(aliases);
 
@@ -103,10 +101,8 @@ export function reverseResolveAlias(
     }
   }
 
-  return matches.length > 0
-    ? // Sort by length, longest (more specific) first
-      matches.sort((a, b) => b.length - a.length)
-    : undefined;
+  // Sort by length, longest (more specific) first
+  return matches.sort((a, b) => b.length - a.length);
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -74,14 +74,23 @@ export function resolveAlias(path: string, aliases: Record<string, string>) {
   return _path;
 }
 
+/**
+ * Resolves a path string to its possible alias.
+ *
+ * Returns an array of possible alias resolutions, sorted by specificity (longest first).
+ *
+ * Returns `undefined` if no alias is found.
+ */
 export function reverseResolveAlias(
   path: string,
   aliases: Record<string, string>,
-) {
+): undefined | string[] {
   const _path = normalizeWindowsPath(path);
   aliases = normalizeAliases(aliases);
 
-  for (const [to, alias] of Object.entries(aliases).reverse()) {
+  const matches: string[] = [];
+
+  for (const [to, alias] of Object.entries(aliases)) {
     if (!_path.startsWith(alias)) {
       continue;
     }
@@ -90,10 +99,14 @@ export function reverseResolveAlias(
     const _alias = hasTrailingSlash(alias) ? alias.slice(0, -1) : alias;
 
     if (hasTrailingSlash(_path[_alias.length])) {
-      return join(to, _path.slice(alias.length));
+      matches.push(join(to, _path.slice(alias.length)));
     }
   }
-  return _path;
+
+  return matches.length > 0
+    ? // Sort by length, longest (more specific) first
+      matches.sort((a, b) => b.length - a.length)
+    : undefined;
 }
 
 /**

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -63,11 +63,17 @@ describe("alias", () => {
   });
 
   describe("reverseResolveAlias", () => {
+    const overrides = {
+      "/root/bingpot/index.ts": ["@/bingpot/index.ts", "bingpot"],
+      "/root/index.js": ["@/index.js", "~"],
+    };
     for (const [to, from] of Object.entries(aliases)) {
-      it(from, () => {
-        expect(reverseResolveAlias(from, aliases)).toBe(to);
+      const expected = overrides[from] || [to];
+      it(`reverseResolveAlias("${from}")`, () => {
+        expect(reverseResolveAlias(from, aliases)).toMatchObject(expected);
       });
     }
+
     it("respects path separators", () => {
       const aliases = {
         "~": "/root",
@@ -75,17 +81,21 @@ describe("alias", () => {
       };
       expect(
         reverseResolveAlias("/root/some/assets/smth.jpg", aliases),
-      ).toMatchInlineSnapshot('"~assets/smth.jpg"');
+      ).toMatchObject(["~/some/assets/smth.jpg", "~assets/smth.jpg"]);
     });
-    it("unchanged", () => {
-      expect(reverseResolveAlias("foo/bar.js", aliases)).toBe("foo/bar.js");
-      expect(reverseResolveAlias("./bar.js", aliases)).toBe("./bar.js");
+
+    it("no match", () => {
+      expect(reverseResolveAlias("foo/bar.js", aliases)).toBeUndefined();
+      expect(reverseResolveAlias("./bar.js", aliases)).toBeUndefined();
     });
+
     it("respect ending with /", () => {
-      expect(reverseResolveAlias("/src/foo/bar", aliases)).toBe("~/foo/bar");
-      expect(reverseResolveAlias("C:/src/foo/bar", aliases)).toBe(
+      expect(reverseResolveAlias("/src/foo/bar", aliases)).toMatchObject([
+        "~/foo/bar",
+      ]);
+      expect(reverseResolveAlias("C:/src/foo/bar", aliases)).toMatchObject([
         "~win/foo/bar",
-      );
+      ]);
     });
   });
 });

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -85,8 +85,8 @@ describe("alias", () => {
     });
 
     it("no match", () => {
-      expect(reverseResolveAlias("foo/bar.js", aliases)).toBeUndefined();
-      expect(reverseResolveAlias("./bar.js", aliases)).toBeUndefined();
+      expect(reverseResolveAlias("foo/bar.js", aliases)).toMatchObject([]);
+      expect(reverseResolveAlias("./bar.js", aliases)).toMatchObject([]);
     });
 
     it("respect ending with /", () => {

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { normalizeAliases, filename, resolveAlias } from "../src/utils";
+import {
+  normalizeAliases,
+  filename,
+  resolveAlias,
+  reverseResolveAlias,
+} from "../src/utils";
 
 describe("alias", () => {
   const _aliases = {
@@ -54,6 +59,33 @@ describe("alias", () => {
     it("respect ending with /", () => {
       expect(resolveAlias("~/foo/bar", aliases)).toBe("/src/foo/bar");
       expect(resolveAlias("~win/foo/bar", aliases)).toBe("C:/src/foo/bar");
+    });
+  });
+
+  describe("reverseResolveAlias", () => {
+    for (const [to, from] of Object.entries(aliases)) {
+      it(from, () => {
+        expect(reverseResolveAlias(from, aliases)).toBe(to);
+      });
+    }
+    it("respects path separators", () => {
+      const aliases = {
+        "~": "/root",
+        "~assets": "/root/some/assets",
+      };
+      expect(
+        reverseResolveAlias("/root/some/assets/smth.jpg", aliases),
+      ).toMatchInlineSnapshot('"~assets/smth.jpg"');
+    });
+    it("unchanged", () => {
+      expect(reverseResolveAlias("foo/bar.js", aliases)).toBe("foo/bar.js");
+      expect(reverseResolveAlias("./bar.js", aliases)).toBe("./bar.js");
+    });
+    it("respect ending with /", () => {
+      expect(reverseResolveAlias("/src/foo/bar", aliases)).toBe("~/foo/bar");
+      expect(reverseResolveAlias("C:/src/foo/bar", aliases)).toBe(
+        "~win/foo/bar",
+      );
     });
   });
 });


### PR DESCRIPTION
Create a reverse lookup to resolve an absolute path towards the aliased path

### ❓ Type of change

- [x] ✨ New feature (a non-breaking change that adds functionality)

### 📚 Description

Created an extra util which allows the user to lookup the alias path from the aliases. Pretty much reverting the `resolveAlias` method. Personal use case is creating some linting rules within Nuxt towards explicit imports using the aliases. Other angles are appreciated

### 📝 Checklist

- [x] I have updated the documentation accordingly.
