### PR TITLE
feat!: set `delimiter` to `;` in windows

### DIFF
--- a/src/path.ts
+++ b/src/path.ts
@@ -18,7 +18,7 @@ const _EXTNAME_RE = /.(\.[^./]+)$/;
 
 export const sep: typeof path.sep = "/";
 
-export const delimiter = /^win/i.test(globalThis.process?.platform) ? ";" : ":";
+export const delimiter = globalThis.process?.platform === "win32" ? ";" : ":";
 
 export const normalize: typeof path.normalize = function (path: string) {
   if (path.length === 0) {

--- a/src/path.ts
+++ b/src/path.ts
@@ -17,7 +17,7 @@ const _ROOT_FOLDER_RE = /^\/([A-Za-z]:)?$/;
 
 // Force POSIX contants
 export const sep = "/";
-export const delimiter = /^win/i.test(process.platform) ? ";" : ":";
+export const delimiter = /^win/i.test(globalThis.process?.platform) ? ";" : ":";
 
 // normalize
 export const normalize: typeof path.normalize = function (path: string) {

--- a/src/path.ts
+++ b/src/path.ts
@@ -17,7 +17,7 @@ const _ROOT_FOLDER_RE = /^\/([A-Za-z]:)?$/;
 
 // Force POSIX contants
 export const sep = "/";
-export const delimiter = ":";
+export const delimiter = /^win/i.test(process.platform) ? ";" : ":";
 
 // normalize
 export const normalize: typeof path.normalize = function (path: string) {

--- a/src/path.ts
+++ b/src/path.ts
@@ -16,8 +16,18 @@ const _DRIVE_LETTER_RE = /^[A-Za-z]:$/;
 const _ROOT_FOLDER_RE = /^\/([A-Za-z]:)?$/;
 const _EXTNAME_RE = /.(\.[^./]+)$/;
 
-export const sep: typeof path.sep = "/";
+/**
+ * Constant for path separator.
+ *
+ * Always equals to `"/"`.
+ */
+export const sep = "/";
 
+/**
+ * The platform-specific file delimiter.
+ *
+ * Equals to `";"` in windows and `":"` in all other platforms.
+ */
 export const delimiter = globalThis.process?.platform === "win32" ? ";" : ":";
 
 export const normalize: typeof path.normalize = function (path: string) {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -332,7 +332,7 @@ runTest("toNamespacedPath", toNamespacedPath, {
 describe("constants", () => {
   it("delimiter should equal :", () => {
     expect(delimiter).to.equal(
-      /^win/i.test(process.platform) ? ";" : ":",
+      /^win/i.test(globalThis.process?.platform) ? ";" : ":",
     );
   });
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -331,7 +331,9 @@ runTest("toNamespacedPath", toNamespacedPath, {
 
 describe("constants", () => {
   it("delimiter should equal :", () => {
-    expect(delimiter).to.equal(":");
+    expect(delimiter).to.equal(
+      /^win/i.test(process.platform) ? ";" : ":",
+    );
   });
 
   it("sep should equal /", () => {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -365,9 +365,9 @@ runTest("toNamespacedPath", toNamespacedPath, {
 });
 
 describe("constants", () => {
-  it("delimiter should equal :", () => {
+  it("delimiter", () => {
     expect(delimiter).to.equal(
-      /^win/i.test(globalThis.process?.platform) ? ";" : ":",
+      globalThis.process?.platform === "win32" ? ";" : ":",
     );
   });
 


### PR DESCRIPTION
**Reference:** #175 

This pull request fixes the issue where the delimiter is a colon (:) on all platforms, including Windows where it should use a semicolon (;).

<!--
IMPORTANT IMPORTANT IMPORTANT IMPORTANT

- Discuss the issue/idea with the maintainers using an issue BEFORE.
- Please keep your changes minimal and split them if you need to.
- Ensure there is a minimal reproduction attached for bug fixes.
- PR titles should follow conventional commit guidelines. Examples:
  - fix(scope): resolve xyz
  - feat: add a new feature
  - docs: improve wording

This will greatly help speed up the review process.

Thanks for your contribution ❤️

IMPORTANT IMPORTANT IMPORTANT IMPORTANT
-->
