### PR TITLE
fix(utils/filename): handle files beginning with a period or without ext

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,10 +57,21 @@ export function resolveAlias(path: string, aliases: Record<string, string>) {
   return _path;
 }
 
-const FILENAME_RE = /(^|[/\\])([^/\\]+?)(?=(\.[^.]+)?$)/;
-
+const SLASH_RE = /[/\\]/;
 export function filename(path: string) {
-  return path.match(FILENAME_RE)?.[2];
+  const base = path.split(SLASH_RE).pop();
+
+  if (!base) {
+    return undefined;
+  }
+
+  const separatorIndex = base.lastIndexOf(".");
+
+  if (separatorIndex <= 0) {
+    return base;
+  }
+
+  return base.slice(0, separatorIndex);
 }
 
 // --- internals ---

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -64,12 +64,24 @@ describe("filename", () => {
     "test.html": "test",
     "/temp/myfile.html": "myfile",
     "./myfile.html": "myfile",
+    "/Users/john.doe/foo/myFile.js": "myFile",
+    "/Users/john.doe/foo/myFile": "myFile",
+    "./.hidden/myFile.ts": "myFile",
+    "./.hidden/myFile": "myFile",
+    "/temp/.gitignore": ".gitignore",
+    "./foo.bar.baz.js": "foo.bar.baz",
 
     // Windows
     "C:\\temp\\": undefined,
     "C:\\temp\\myfile.html": "myfile",
     "\\temp\\myfile.html": "myfile",
     ".\\myfile.html": "myfile",
+    ".\\john.doe\\myfile.js": "myfile",
+    ".\\john.doe\\myfile": "myfile",
+    ".\\.hidden\\myfile.js": "myfile",
+    ".\\.hidden\\myfile": "myfile",
+    "C:\\temp\\.gitignore": ".gitignore",
+    "C:\\temp\\foo.bar.baz.js": "foo.bar.baz",
   };
   for (const file in files) {
     it(file, () => {


### PR DESCRIPTION
(#184)

This change resolves the issue reported with files containing no extension. It also adds tests for filenames such as `.gitignore` or `.env` which begin with a period.

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
