### PR TITLE
test: add additional tests for `extname`

### DIFF
--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -108,6 +108,8 @@ runTest("extname", extname, {
   // POSIX
   "/temp/myfile.html": ".html",
   "./myfile.html": ".html",
+  "./myfile.tar.gz": ".gz",
+  "./myfile.tar.gz.br": ".br",
 
   ".foo": "",
   "..foo": ".foo",


### PR DESCRIPTION
Node behavior for extname("file.tar.gz") is `.gz`

Adding tests to make sure pathe can handle that