### PR TITLE
build: add `type: module` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "repository": "unjs/pathe",
   "license": "MIT",
   "sideEffects": false,
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
This is needed for TypeScript project to load the ESM code.

Resolves #191 

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
