### PR TITLE
fix(parse)!: fix root handling to be consistent with node

### DIFF
--- a/src/path.ts
+++ b/src/path.ts
@@ -15,6 +15,7 @@ const _IS_ABSOLUTE_RE = /^[/\\](?![/\\])|^[/\\]{2}(?!\.)|^[A-Za-z]:[/\\]/;
 const _DRIVE_LETTER_RE = /^[A-Za-z]:$/;
 const _ROOT_FOLDER_RE = /^\/([A-Za-z]:)?$/;
 const _EXTNAME_RE = /.(\.[^./]+)$/;
+const _PATH_ROOT_RE = /^[/\\]|^[a-zA-Z]:[/\\]/;
 
 // Force POSIX constants
 
@@ -268,11 +269,9 @@ export const basename: typeof path.basename = function (p, extension) {
     : lastSegment;
 };
 
-const PATH_ROOT_RE = /^[/\\]|^[a-zA-Z]:[/\\]/;
-
 export const parse: typeof path.parse = function (p) {
   // The root of the path such as '/' or 'c:\'
-  let root = PATH_ROOT_RE.exec(p)?.[0]?.replace(/\\/g, "/") ?? "";
+  const root = _PATH_ROOT_RE.exec(p)?.[0]?.replace(/\\/g, "/") || "";
   const base = basename(p);
   const extension = extname(base);
   return {

--- a/src/path.ts
+++ b/src/path.ts
@@ -261,7 +261,12 @@ export const basename: typeof path.basename = function (p, extension) {
 
 // parse
 export const parse: typeof path.parse = function (p) {
-  const root = normalizeWindowsPath(p).split("/").shift() || "/";
+  let root = normalizeWindowsPath(p).split("/").shift();
+  if (root === "") {
+    root = "/";
+  } else {
+    root += "/";
+  }
   const base = basename(p);
   const extension = extname(base);
   return {

--- a/src/path.ts
+++ b/src/path.ts
@@ -268,13 +268,11 @@ export const basename: typeof path.basename = function (p, extension) {
     : lastSegment;
 };
 
+const PATH_ROOT_RE = /^[/\\]|^[a-zA-Z]:[/\\]/;
+
 export const parse: typeof path.parse = function (p) {
-  let root = normalizeWindowsPath(p).split("/").shift();
-  if (root === "") {
-    root = "/";
-  } else {
-    root += "/";
-  }
+  // The root of the path such as '/' or 'c:\'
+  let root = PATH_ROOT_RE.exec(p)?.[0]?.replace(/\\/g, "/") ?? "";
   const base = basename(p);
   const extension = extname(base);
   return {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -208,7 +208,7 @@ it("parse", () => {
     name: "file",
   });
   expect(parse("./dir/file")).to.deep.equal({
-    root: ".",
+    root: "./",
     dir: "./dir",
     base: "file",
     ext: "",
@@ -217,18 +217,41 @@ it("parse", () => {
 
   // Windows
   expect(parse("C:\\path\\dir\\file.txt")).to.deep.equal({
-    root: "C:",
+    root: "C:/",
     dir: "C:/path/dir",
     base: "file.txt",
     ext: ".txt",
     name: "file",
   });
   expect(parse(".\\dir\\file")).to.deep.equal({
-    root: ".",
+    root: "./",
     dir: "./dir",
     base: "file",
     ext: "",
     name: "file",
+  });
+  // Windows path can have spaces
+  expect(parse("C:\\pa th\\dir\\file.txt")).to.deep.equal({
+    root: "C:/",
+    dir: "C:/pa th/dir",
+    base: "file.txt",
+    ext: ".txt",
+    name: "file",
+  });
+  // Test with normalized windows path
+  expect(parse("C:/path/dir/file.txt")).to.deep.equal({
+    root: 'C:/',
+    dir: 'C:/path/dir',
+    base: 'file.txt',
+    ext: '.txt',
+    name: 'file'
+  })
+  expect(parse("C:/pa th/dir/file.txt")).to.deep.equal({
+    root: 'C:/',
+    dir: 'C:/pa th/dir',
+    base: 'file.txt',
+    ext: '.txt',
+    name: 'file'
   });
 });
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -235,7 +235,7 @@ it("parse", () => {
     name: "file",
   });
   expect(parse("./dir/file")).to.deep.equal({
-    root: "./",
+    root: "",
     dir: "./dir",
     base: "file",
     ext: "",
@@ -251,7 +251,7 @@ it("parse", () => {
     name: "file",
   });
   expect(parse(String.raw`.\dir\file`)).to.deep.equal({
-    root: "./",
+    root: "",
     dir: "./dir",
     base: "file",
     ext: "",

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -258,7 +258,7 @@ it("parse", () => {
     name: "file",
   });
   // Windows path can have spaces
-  expect(parse("C:\\pa th\\dir\\file.txt")).to.deep.equal({
+  expect(parse(String.raw`C:\pa th\dir\file.txt`)).to.deep.equal({
     root: "C:/",
     dir: "C:/pa th/dir",
     base: "file.txt",


### PR DESCRIPTION
resolves #167

Rework of #168 by @prisis

`root` in `parse` result should be strictly either `/` or `X:/` (as per node util docs)

This PR:
- Removes `.` fallback for posix paths
- Adds trailing `/` to win32 paths


---

<img width="841" alt="image" src="https://github.com/user-attachments/assets/1e25b921-3395-482a-920a-81c86aca6843" />


```js
import path from 'node:path'
import pathe from 'pathe'

console.log('Node version: ' + process.version + "\n");

for (const p of [".\\dir\\file", "C:\\path\\dir\\file.txt"]) {
  console.log(p);
  console.log("   path  (posix)  : ", JSON.stringify(path.posix.parse(p)));
  console.log("   path  (win32)  : ", JSON.stringify(path.win32.parse(p)));
  console.log("   pathe (new)    : ", JSON.stringify(pathe.parse(p)));
  console.log();
}

```

