### PR TITLE
fix(join)!: preserve normalized unc paths

### DIFF
--- a/src/path.ts
+++ b/src/path.ts
@@ -69,26 +69,28 @@ export const normalize: typeof path.normalize = function (path: string) {
   return isPathAbsolute && !isAbsolute(path) ? `/${path}` : path;
 };
 
-export const join: typeof path.join = function (...arguments_) {
-  if (arguments_.length === 0) {
-    return ".";
-  }
+export const join: typeof path.join = function (...segments) {
+  let path = "";
 
-  let joined: string;
-  for (const argument of arguments_) {
-    if (argument && argument.length > 0) {
-      if (joined === undefined) {
-        joined = argument;
+  for (const seg of segments) {
+    if (!seg) {
+      continue;
+    }
+    if (path.length > 0) {
+      const pathTrailing = path[path.length - 1] === "/";
+      const segLeading = seg[0] === "/";
+      const both = pathTrailing && segLeading;
+      if (both) {
+        path += seg.slice(1);
       } else {
-        joined += `/${argument}`;
+        path += pathTrailing || segLeading ? seg : `/${seg}`;
       }
+    } else {
+      path += seg;
     }
   }
-  if (joined === undefined) {
-    return ".";
-  }
 
-  return normalize(joined.replace(/\/\/+/g, "/"));
+  return normalize(path);
 };
 
 function cwd() {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -162,6 +162,7 @@ runTest("join", join, [
   ["", "."],
   ["./", "./"],
   ["", "/foo", "/foo"],
+  ["/foo", "//bar", "/foo/bar"],
   ["/", "/path", "/path"],
   ["/test//", "//path", "/test/path"],
   ["some/nodejs/deep", "../path", "some/nodejs/path"],

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -159,6 +159,9 @@ runTest("format", format, [
 runTest("join", join, [
   ["."],
   [undefined, "."],
+  ["", "."],
+  ["./", "./"],
+  ["", "/foo", "/foo"],
   ["/", "/path", "/path"],
   ["/test//", "//path", "/test/path"],
   ["some/nodejs/deep", "../path", "some/nodejs/path"],
@@ -186,6 +189,7 @@ runTest("join", join, [
   [String.raw`\\server\share\file`, String.raw`..\path`, "//server/share/path"],
   [String.raw`\\.\c:\temp\file`, String.raw`..\path`, "//./c:/temp/path"],
   [String.raw`\\server/share/file`, "../path", "//server/share/path"],
+  [String.raw`//server/share/file`, "../path", "//server/share/path"],
 ]);
 
 runTest("normalize", normalize, {


### PR DESCRIPTION
resolves #178 (https://github.com/unjs/pathe/issues/178#issuecomment-2328147213)

Even though `normalize` is UNC aware, `join` utility blindly strips the leading UNC indicator with a final replacement.

This PR changes `join` implementation to avoid global regex (normalize finally takes care of proper normalization).

Note: While all existing tests pass, this is a potential behavior change

Note: This PR does **not** add URL compatibility to path utils as it needs changes to more utils and it is out of scope / non goal.

 