### PR TITLE
fix: mixed `posix`/`win32` namespaces

### DIFF
--- a/src/_path.ts
+++ b/src/_path.ts
@@ -26,13 +26,6 @@ const _PATH_ROOT_RE = /^[/\\]|^[a-zA-Z]:[/\\]/;
  */
 export const sep = "/";
 
-/**
- * The platform-specific file delimiter.
- *
- * Equals to `";"` in windows and `":"` in all other platforms.
- */
-export const delimiter = globalThis.process?.platform === "win32" ? ";" : ":";
-
 export const normalize: typeof path.normalize = function (path: string) {
   if (path.length === 0) {
     return ".";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,42 @@
-import type NodePath from "node:path";
+import type { posix as Posix, win32 as Win32, PlatformPath } from "node:path";
 
-import * as path from "./path";
+import * as _path from "./_path";
 
-export * from "./path";
+export * from "./_path";
 
-export type Pathe = Omit<typeof NodePath, "posix" | "win32">;
+/**
+ * The platform-specific file delimiter.
+ *
+ * Equals to `";"` in windows and `":"` in all other platforms.
+ */
+export const delimiter: ";" | ":" =
+  globalThis.process?.platform === "win32" ? ";" : ":";
 
-export const posix = path satisfies Pathe;
+export const posix = {
+  ..._path,
+  delimiter: ":",
+  get posix() {
+    return posix;
+  },
+  get win32() {
+    return win32;
+  },
+} as typeof Posix;
 
-export const win32 = path satisfies Pathe;
+export const win32 = {
+  ..._path,
+  delimiter: ";",
+  get posix() {
+    return posix;
+  },
+  get win32() {
+    return win32;
+  },
+} as typeof Win32;
 
-export default path satisfies Pathe;
+export default {
+  ...posix,
+  delimiter,
+  posix,
+  win32,
+} as PlatformPath;

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,18 +19,18 @@ const _platforms = { posix: undefined, win32: undefined } as {
   win32: typeof Win32;
 };
 
-const mix = (obj, del: ";" | ":" = delimiter) => {
-  return new Proxy(obj, {
+const mix = (del: ";" | ":" = delimiter) => {
+  return new Proxy(_path, {
     get(_, prop) {
       if (prop === "delimiter") return del;
       if (prop === "posix") return posix;
       if (prop === "win32") return win32;
-      return _platforms[prop] || obj[prop];
+      return _platforms[prop] || _path[prop];
     },
-  });
+  }) as unknown as PlatformPath;
 };
 
-export const posix = /* @__PURE__ */ mix(_path, ":") as typeof Posix;
-export const win32 = /* @__PURE__ */ mix(_path, ";") as typeof Win32;
+export const posix = /* @__PURE__ */ mix(":") as typeof Posix;
+export const win32 = /* @__PURE__ */ mix(";") as typeof Win32;
 
-export default /* @__PURE__ */ mix(posix) as PlatformPath;
+export default posix;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { join } from "./path";
+import { join } from "./_path";
 import { normalizeWindowsPath } from "./_internal";
 
 const pathSeparators = new Set(["/", "\\", undefined]);

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -16,6 +16,8 @@ import {
   toNamespacedPath,
   normalizeString,
   matchesGlob,
+  posix,
+  win32,
 } from "../src";
 
 import { normalizeWindowsPath } from "../src/_internal";
@@ -397,6 +399,8 @@ runTest("toNamespacedPath", toNamespacedPath, {
 
 describe("constants", () => {
   it("delimiter", () => {
+    expect(posix.delimiter).to.equal(":");
+    expect(win32.delimiter).to.equal(";");
     expect(delimiter).to.equal(
       globalThis.process?.platform === "win32" ? ";" : ":",
     );
@@ -404,6 +408,13 @@ describe("constants", () => {
 
   it("sep should equal /", () => {
     expect(separator).to.equal("/");
+  });
+});
+
+describe("mixed namespaces", () => {
+  it("nested namespaces work", () => {
+    expect(posix.win32.posix.delimiter).to.equal(":");
+    expect(win32.posix.win32.delimiter).to.equal(";");
   });
 });
 


### PR DESCRIPTION
In #176 (2.0) we have introduced `posix` and `win32` top level exports to match exact `node:path` exports as drop-in replacement. 

However it wans't matching runtime behavior (found during unenv upgrade). `path.posix.win32` can be chained.

This PR also fixes the issue that `pathe.posix.delimiter` is always set to `:` now + allows strict treeshaking (with esbuild)