### PR TITLE
chore: enable strict typescript compilation

### DIFF
--- a/src/_path.ts
+++ b/src/_path.ts
@@ -146,7 +146,8 @@ export function normalizeString(path: string, allowAboveRoot: boolean) {
   let char: string | null = null;
   for (let index = 0; index <= path.length; ++index) {
     if (index < path.length) {
-      char = path[index];
+      // casted because we know it exists thanks to the length check
+      char = path[index] as string;
     } else if (char === "/") {
       break;
     } else {
@@ -219,8 +220,15 @@ export const extname: typeof path.extname = function (p) {
 };
 
 export const relative: typeof path.relative = function (from, to) {
-  const _from = resolve(from).replace(_ROOT_FOLDER_RE, "$1").split("/");
-  const _to = resolve(to).replace(_ROOT_FOLDER_RE, "$1").split("/");
+  // we cast these because `split` will always be at least one string
+  const _from = resolve(from).replace(_ROOT_FOLDER_RE, "$1").split("/") as [
+    string,
+    ...string[],
+  ];
+  const _to = resolve(to).replace(_ROOT_FOLDER_RE, "$1").split("/") as [
+    string,
+    ...string[],
+  ];
 
   // Different windows drive letters
   if (_to[0][1] === ":" && _from[0][1] === ":" && _from[0] !== _to[0]) {
@@ -243,7 +251,7 @@ export const dirname: typeof path.dirname = function (p) {
     .replace(/\/$/, "")
     .split("/")
     .slice(0, -1);
-  if (segments.length === 1 && _DRIVE_LETTER_RE.test(segments[0])) {
+  if (segments.length === 1 && _DRIVE_LETTER_RE.test(segments[0] as string)) {
     segments[0] += "/";
   }
   return segments.join("/") || (isAbsolute(p) ? "/" : ".");

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,9 +14,10 @@ export const delimiter: ";" | ":" = /* @__PURE__ */ (() =>
 
 // Mix namespaces without side-effects of object to allow tree-shaking
 
-const _platforms = { posix: undefined, win32: undefined } as {
+const _platforms = { posix: undefined, win32: undefined } as unknown as {
   posix: NodePath["posix"];
   win32: NodePath["win32"];
+  [key: PropertyKey]: unknown;
 };
 
 const mix = (del: ";" | ":" = delimiter) => {
@@ -25,7 +26,7 @@ const mix = (del: ";" | ":" = delimiter) => {
       if (prop === "delimiter") return del;
       if (prop === "posix") return posix;
       if (prop === "win32") return win32;
-      return _platforms[prop] || _path[prop];
+      return _platforms[prop] || _path[prop as keyof typeof _path];
     },
   }) as unknown as NodePath;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,7 +33,7 @@ export function normalizeAliases(_aliases: Record<string, string>) {
       }
 
       if (
-        aliases[key].startsWith(alias) &&
+        aliases[key]?.startsWith(alias) &&
         pathSeparators.has(aliases[key][alias.length])
       ) {
         aliases[key] = aliases[alias] + aliases[key].slice(alias.length);

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -68,7 +68,7 @@ describe("alias", () => {
       "/root/index.js": ["@/index.js", "~"],
     };
     for (const [to, from] of Object.entries(aliases)) {
-      const expected = overrides[from] || [to];
+      const expected = overrides[from as keyof typeof overrides] || [to];
       it(`reverseResolveAlias("${from}")`, () => {
         expect(reverseResolveAlias(from, aliases)).toMatchObject(expected);
       });
@@ -127,7 +127,7 @@ describe("filename", () => {
   };
   for (const file in files) {
     it(file, () => {
-      expect(filename(file)).toEqual(files[file]);
+      expect(filename(file)).toEqual(files[file as keyof typeof files]);
     });
   }
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,15 @@
     "module": "ESNext",
     "moduleResolution": "Node",
     "skipLibCheck": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "strict": true,
+    "verbatimModuleSyntax": true
   },
   "include": [
     "src",


### PR DESCRIPTION
Enables most of what's in the unjs tsconfig template, plus the following:

- `noUnusedLocals`
- `noUnusedParameters`

i didn't take the entire unjs template because it'd mean changing the module/moduleResolution/moduleDetection

@pi0 almost all of the casts are because `noUncheckedIndexedAccess` is true. we can turn it off if you think we will do that quite often (e.g. when we check length of something, we know it then has `[0]` but typescript doesn't)
