### PR TITLE
fix: `win32.sep` should be backslash

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ const mix = (del: ";" | ":" = delimiter) => {
       if (prop === "delimiter") return del;
       if (prop === "posix") return posix;
       if (prop === "win32") return win32;
+      if (prop === "sep" && del === ";") return "\\";
       return _platforms[prop] || _path[prop as keyof typeof _path];
     },
   }) as unknown as NodePath;

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -413,6 +413,10 @@ describe("constants", () => {
   it("sep should equal /", () => {
     expect(separator).to.equal("/");
   });
+
+  it("win32 sep should equal \\", () => {
+    expect(win32.sep).to.equal("\\");
+  });
 });
 
 describe("mixed namespaces", () => {


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

Hi, I want to use `pathe` in @rollup/pluginutils to support browser environments. https://github.com/rollup/plugins/pull/1838

For this [line](https://github.com/rollup/plugins/blob/d64f8d69d0ca138161fc98c0b2cd2b5df73c2895/packages/pluginutils/src/normalizePath.ts#L5), the `win32.sep` result is different.
`require('path').win32.sep === '\\'` 
`require('pathe').win32.sep === '/'`
