### PR TITLE
fix: parse() returns empty string for dir when path has no directory component

### DIFF
--- a/src/_path.ts
+++ b/src/_path.ts
@@ -291,9 +291,11 @@ export const parse: typeof path.parse = function (p) {
   const root = _PATH_ROOT_RE.exec(p)?.[0]?.replace(/\\/g, "/") || "";
   const base = basename(p);
   const extension = extname(base);
+  const dir = dirname(p);
   return {
     root,
-    dir: dirname(p),
+    // node:path returns "" (not ".") when the path has no directory component
+    dir: dir === "." && !normalizeWindowsPath(p).includes("/") ? "" : dir,
     base,
     ext: extension,
     name: base.slice(0, base.length - extension.length),

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -295,6 +295,44 @@ it("parse", () => {
     ext: ".txt",
     name: "file",
   });
+
+  // Bare filenames with no directory component — dir must be "" not "."
+  // node:path.posix.parse("foo.txt").dir === ""
+  expect(parse("foo.txt")).to.deep.equal({
+    root: "",
+    dir: "",
+    base: "foo.txt",
+    ext: ".txt",
+    name: "foo",
+  });
+  expect(parse("foo")).to.deep.equal({
+    root: "",
+    dir: "",
+    base: "foo",
+    ext: "",
+    name: "foo",
+  });
+  expect(parse(".")).to.deep.equal({
+    root: "",
+    dir: "",
+    base: ".",
+    ext: "",
+    name: ".",
+  });
+  expect(parse("..")).to.deep.equal({
+    root: "",
+    dir: "",
+    base: "..",
+    ext: "",
+    name: "..",
+  });
+  expect(parse(".gitignore")).to.deep.equal({
+    root: "",
+    dir: "",
+    base: ".gitignore",
+    ext: "",
+    name: ".gitignore",
+  });
 });
 
 runTest("relative", relative, [


### PR DESCRIPTION
parse() currently returns "." for the dir field on bare filenames like "foo.txt" or ".gitignore". node:path.posix.parse on those same inputs returns "".

The contract from the node:path docs is that parse().dir is the directory portion of the path, which is empty when there is no directory (no slash in the path). A relative "." is what dirname() returns for use in join/resolve context, but parse() is a decomposition function and should follow the node:path contract.

Before this fix:

    parse("foo.txt").dir  // "."
    parse(".gitignore").dir  // "."
    parse(".").dir  // "."

After:

    parse("foo.txt").dir  // ""
    parse(".gitignore").dir  // ""
    parse(".").dir  // ""

Paths that actually contain a directory component are unaffected:

    parse("./foo.txt").dir  // "." (correct, has a slash)
    parse("/a/b.txt").dir  // "/a" (correct)
    parse("C:\\foo\\bar.txt").dir  // "C:/foo" (correct)

The fix is a single conditional in parse(): when dirname returns "." and the normalized path contains no slash, the dir field is set to "" to match node:path behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed path parsing to correctly return an empty string for the `dir` field when parsing filenames without directory components (e.g., `foo.txt`, `.gitignore`), aligning with standard path conventions.

* **Tests**
  * Added test coverage for bare filename parsing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->