### PR TITLE
fix(parse): return empty string for dir when path has no directory component

### DIFF
--- a/src/_path.ts
+++ b/src/_path.ts
@@ -291,9 +291,29 @@ export const parse: typeof path.parse = function (p) {
   const root = _PATH_ROOT_RE.exec(p)?.[0]?.replace(/\\/g, "/") || "";
   const base = basename(p);
   const extension = extname(base);
+
+  // Compute `dir` directly from the path string to match Node.js behavior.
+  // Using dirname(p) would return '.' for paths with no directory component
+  // (e.g. 'foo', '', '.', '..'), but Node.js path.parse() returns '' in those cases.
+  const normalizedP = normalizeWindowsPath(p);
+  const withoutTrailing = normalizedP.replace(/\/+$/, "");
+  const lastSlashIndex = withoutTrailing.lastIndexOf("/");
+  let dir: string;
+  if (!base) {
+    // No base component (e.g. '/' or '//') — dir equals the root
+    dir = root || "";
+  } else if (lastSlashIndex === -1) {
+    // No slash in the path — no directory component
+    dir = "";
+  } else {
+    const dirPart = withoutTrailing.slice(0, lastSlashIndex);
+    // If the slice is empty the path looks like '/foo', so the dir is '/'
+    dir = dirPart || (isAbsolute(p) ? "/" : "");
+  }
+
   return {
     root,
-    dir: dirname(p),
+    dir,
     base,
     ext: extension,
     name: base.slice(0, base.length - extension.length),

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -295,6 +295,62 @@ it("parse", () => {
     ext: ".txt",
     name: "file",
   });
+
+  // Paths with no directory component should return dir:'' not dir:'.'
+  // (matches Node.js path.parse() behavior)
+  expect(parse("")).to.deep.equal({
+    root: "",
+    dir: "",
+    base: "",
+    ext: "",
+    name: "",
+  });
+  expect(parse(".")).to.deep.equal({
+    root: "",
+    dir: "",
+    base: ".",
+    ext: "",
+    name: ".",
+  });
+  expect(parse("..")).to.deep.equal({
+    root: "",
+    dir: "",
+    base: "..",
+    ext: "",
+    name: "..",
+  });
+  expect(parse("file.txt")).to.deep.equal({
+    root: "",
+    dir: "",
+    base: "file.txt",
+    ext: ".txt",
+    name: "file",
+  });
+  expect(parse("file")).to.deep.equal({
+    root: "",
+    dir: "",
+    base: "file",
+    ext: "",
+    name: "file",
+  });
+
+  // Root-only paths
+  expect(parse("/")).to.deep.equal({
+    root: "/",
+    dir: "/",
+    base: "",
+    ext: "",
+    name: "",
+  });
+
+  // Trailing-slash paths
+  expect(parse("/home/user/")).to.deep.equal({
+    root: "/",
+    dir: "/home",
+    base: "user",
+    ext: "",
+    name: "user",
+  });
 });
 
 runTest("relative", relative, [


### PR DESCRIPTION
## Problem

`parse()` uses `dirname(p)` to compute the `dir` field of the returned object. However, `dirname()` returns `'.'` for paths that contain no directory separator — `''`, `'.'`, `'..'`, `'foo'`, `'file.txt'`, etc. This diverges from Node.js `path.parse()`, which returns `''` for those cases.

```js
// Before this fix
pathe.parse('file.txt').dir  // '.'   ← wrong, Node.js returns ''
pathe.parse('').dir          // '.'   ← wrong, Node.js returns ''
pathe.parse('.').dir         // '.'   ← wrong, Node.js returns ''
pathe.parse('..').dir        // '.'   ← wrong, Node.js returns ''
```

`dirname` returning `'.'` is correct behaviour for that function (it matches `path.dirname`), but `parse` is supposed to extract the directory _portion of the string_, not resolve a logical parent — Node.js implements them differently internally.

## Fix

Compute `dir` directly from the normalized path string instead of delegating to `dirname()`:

1. Normalize backslashes to forward slashes.
2. Strip trailing slashes (so `'/home/user/'` gives dir `'/home'`, not `'/home/user'`).
3. Find the last `/` and slice — if the slice is empty and the path is absolute, use `'/'`; if there is no base component (root-only path like `'/'`), use the root.

## Tests

Added cases to the existing `parse` test block for:
- `''`, `'.'`, `'..'`, `'file'`, `'file.txt'` — all should have `dir: ''`
- `'/'` — root-only path, `dir: '/'`
- `'/home/user/'` — trailing-slash path, `dir: '/home'`

All 343 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved `path.parse()` handling for edge cases including root paths, paths without directory components, and trailing slashes.

* **Tests**
  * Added comprehensive test coverage for path parsing edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->