### PR TITLE
fix(extname): resolve extension from the last path segment

### DIFF
--- a/src/_path.ts
+++ b/src/_path.ts
@@ -215,8 +215,9 @@ export const toNamespacedPath: typeof path.toNamespacedPath = function (p) {
 };
 
 export const extname: typeof path.extname = function (p) {
-  if (p === "..") return "";
-  const match = _EXTNAME_RE.exec(normalizeWindowsPath(p));
+  const base = basename(p);
+  if (base === "..") return "";
+  const match = _EXTNAME_RE.exec(base);
   return (match && match[1]) || "";
 };
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -139,6 +139,15 @@ runTest("extname", extname, {
   "foo.": ".",
   "...": ".",
 
+  // Multi-segment input: extension is resolved from the last segment only,
+  // consistent with node:path and `parse().ext` (#203 only handled bare "..").
+  "dir/.bashrc": "",
+  "foo/bar.tar.gz": ".gz",
+  "a/..": "",
+  "/foo/..": "",
+  "a/.": "",
+  "trailing.dir/": ".dir",
+
   // Windows
   "C:\\temp\\myfile.html": ".html",
   "\\temp\\myfile.html": ".html",


### PR DESCRIPTION
`extname()` runs the extension regex against the whole normalized path, so a separator or a trailing slash earlier in the input leaks into the result. `parse()` already resolves the extension from `basename(p)` and matches `node:path`, which means the two disagree for the same input:

| input | `extname()` | `parse().ext` | `node:path` |
| --- | --- | --- | --- |
| `dir/.bashrc` | `".bashrc"` | `""` | `""` |
| `a/..` | `"."` | `""` | `""` |
| `/foo/..` | `"."` | `""` | `""` |
| `a/.` | `"."` | `""` | `""` |
| `trailing.dir/` | `""` | `".dir"` | `".dir"` |

#203 added `if (p === "..") return ""`, but that only covers the bare `..` string, not `a/..`, a dot-file inside a directory, or a trailing slash.

This resolves the extension from `basename(p)`, the same way `parse()` already does, so `extname()` lines up with both `parse().ext` and `node:path`.

Checked against `node:path` over the existing cases plus a sweep of separator / dot-file / `..` combinations: every input now returns the same value as `node.extname`, `node.parse().ext` and pathe's own `parse().ext`. The existing `extname` tests still pass, and reverting the change reproduces the table above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extension detection for paths with multiple segments, so the extension is now taken from the final path part.
  * Better handles edge cases like `..`, `.`, and trailing directory-style paths, returning the expected empty or final-segment extension values.
* **Tests**
  * Added coverage for multi-segment paths and special trailing path cases to verify extension handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->