### PR TITLE
refactor!: built-in glob matcher

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -1,7 +1,4 @@
-import { dirname, resolve } from "node:path";
-import { writeFile, mkdir } from "node:fs/promises";
 import { defineBuildConfig } from "obuild/config";
-import { build, type BuildOptions, transform } from "esbuild";
 
 export default defineBuildConfig({
   entries: [
@@ -13,42 +10,4 @@ export default defineBuildConfig({
       ]
     }
   ],
-  hooks: {
-    async rolldownConfig(cfg) {
-      cfg.resolve!.alias ??= {}
-      cfg.resolve!.alias["zeptomatch"] = await buildZeptomatch();
-    }
-  },
 });
-
-async function buildZeptomatch() {
-  let bundle = await build(<BuildOptions>{
-    format: "iife",
-    globalName: "__lib__",
-    bundle: true,
-    write: false,
-    stdin: {
-      resolveDir: process.cwd(),
-      contents: /* js */ `export { default } from "zeptomatch";`,
-    },
-  }).then((r) => r.outputFiles![0].text);
-
-  bundle = (await transform(bundle, { minify: true })).code!;
-
-  bundle = /* js */ `
-let _lazyMatch = () => { ${bundle}; return __lib__.default || __lib__; };
-let _match;
-export default (path, pattern) => {
-  if (!_match) {
-    _match = _lazyMatch();
-    _lazyMatch = null;
-  }
-  return _match(path, pattern);
-};
-  `;
-
-  const outFile = resolve("tmp/node_modules/zeptomatch/zeptomatch.min.mjs");
-  await mkdir(dirname(outFile), { recursive: true });
-  await writeFile(outFile, bundle);
-  return outFile;
-}

--- a/package.json
+++ b/package.json
@@ -32,13 +32,11 @@
     "@typescript/native-preview": "7.0.0-dev.20260703.1",
     "@vitest/coverage-v8": "^4.1.9",
     "changelogen": "^0.6.2",
-    "esbuild": "^0.28.1",
     "obuild": "^0.4.37",
     "oxfmt": "^0.57.0",
     "oxlint": "^1.72.0",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.9",
-    "zeptomatch": "^2.1.0"
+    "vitest": "^4.1.9"
   },
   "packageManager": "pnpm@11.9.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       changelogen:
         specifier: ^0.6.2
         version: 0.6.2(magicast@0.5.3)
-      esbuild:
-        specifier: ^0.28.1
-        version: 0.28.1
       obuild:
         specifier: ^0.4.37
         version: 0.4.37(@typescript/native-preview@7.0.0-dev.20260703.1)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(jiti@2.7.0)(magicast@0.5.3)(typescript@6.0.3)
@@ -38,9 +35,6 @@ importers:
       vitest:
         specifier: ^4.1.9
         version: 4.1.9(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0))
-      zeptomatch:
-        specifier: ^2.1.0
-        version: 2.1.0
 
 packages:
 
@@ -867,12 +861,6 @@ packages:
     resolution: {integrity: sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw==}
     hasBin: true
 
-  grammex@3.1.12:
-    resolution: {integrity: sha512-6ufJOsSA7LcQehIJNCO7HIBykfM7DXQual0Ny780/DEcJIpBlHRvcqEBWGPYd7hrXL2GJ3oJI1MIhaXjWmLQOQ==}
-
-  graphmatch@1.1.1:
-    resolution: {integrity: sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg==}
-
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -1269,9 +1257,6 @@ packages:
   wsl-utils@0.1.0:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
-
-  zeptomatch@2.1.0:
-    resolution: {integrity: sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==}
 
 snapshots:
 
@@ -1835,6 +1820,7 @@ snapshots:
       '@esbuild/win32-arm64': 0.28.1
       '@esbuild/win32-ia32': 0.28.1
       '@esbuild/win32-x64': 0.28.1
+    optional: true
 
   estree-walker@3.0.3:
     dependencies:
@@ -1856,10 +1842,6 @@ snapshots:
       resolve-pkg-maps: 1.0.0
 
   giget@3.3.0: {}
-
-  grammex@3.1.12: {}
-
-  graphmatch@1.1.1: {}
 
   has-flag@4.0.0: {}
 
@@ -2207,8 +2189,3 @@ snapshots:
   wsl-utils@0.1.0:
     dependencies:
       is-wsl: 3.1.1
-
-  zeptomatch@2.1.0:
-    dependencies:
-      grammex: 3.1.12
-      graphmatch: 1.1.1

--- a/src/_glob.ts
+++ b/src/_glob.ts
@@ -1,0 +1,442 @@
+/*
+Minimal glob matcher ported from zeptomatch.
+
+Only the logic needed by `matchesGlob` is included: globs are compiled to a single
+`RegExp` (the `partial` option is never used, which collapses the original
+graph-to-regex compiler down to a plain recursive walk).
+
+Based on zeptomatch (and its `grammex` / `graphmatch` dependencies):
+ - https://github.com/fabiospampinato/zeptomatch
+
+The MIT License (MIT)
+Copyright (c) 2023-present Fabio Spampinato
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+*/
+
+// --- Minimal parser combinators (subset of `grammex`) ---
+
+interface State {
+  input: string;
+  index: number;
+  output: any[];
+}
+
+type Rule = (state: State) => boolean;
+
+type Handler = ((...args: any[]) => any) | string | undefined;
+
+const _CAPTURING_RE = /\\\(|\((?!\?(?::|=|!|<=|<!))/;
+
+const _apply = (state: State, start: number, handler: (outputs: any[]) => any): void => {
+  const output = handler(state.output.splice(start));
+  if (output !== undefined) {
+    state.output.push(output);
+  }
+};
+
+const match = (target: string | RegExp, handler?: Handler): Rule => {
+  if (typeof target === "string") {
+    return (state) => {
+      if (!state.input.startsWith(target, state.index)) {
+        return false;
+      }
+      if (handler !== undefined) {
+        const output = typeof handler === "function" ? handler(target) : handler;
+        if (output !== undefined) {
+          state.output.push(output);
+        }
+      }
+      state.index += target.length;
+      return true;
+    };
+  }
+  const re = new RegExp(
+    target.source,
+    target.flags.includes("y") ? target.flags : `${target.flags}y`,
+  );
+  const capturing =
+    _CAPTURING_RE.test(target.source) && typeof handler === "function" && handler.length >= 2;
+  return (state) => {
+    re.lastIndex = state.index;
+    const matched = re.exec(state.input);
+    if (!matched) {
+      return false;
+    }
+    // Capture the end index before running the handler: a handler may re-enter
+    // the parser (e.g. negation compiling a nested glob) and clobber `lastIndex`.
+    const indexEnd = re.lastIndex;
+    if (handler !== undefined) {
+      const output =
+        typeof handler !== "function"
+          ? handler
+          : capturing
+            ? handler(...matched)
+            : handler(matched[0]);
+      if (output !== undefined) {
+        state.output.push(output);
+      }
+    }
+    state.index = indexEnd;
+    return true;
+  };
+};
+
+const and = (rules: Rule[], handler?: (outputs: any[]) => any): Rule => {
+  return (state) => {
+    const index = state.index;
+    const length = state.output.length;
+    for (const rule of rules) {
+      if (!rule(state)) {
+        state.index = index;
+        state.output.length = length;
+        return false;
+      }
+    }
+    if (handler) {
+      _apply(state, length, handler);
+    }
+    return true;
+  };
+};
+
+const or = (rules: Rule[], handler?: (outputs: any[]) => any): Rule => {
+  return (state) => {
+    const length = state.output.length;
+    for (const rule of rules) {
+      if (rule(state)) {
+        if (handler) {
+          _apply(state, length, handler);
+        }
+        return true;
+      }
+    }
+    return false;
+  };
+};
+
+const repeat = (rule: Rule, min: number, max: number, handler?: (outputs: any[]) => any): Rule => {
+  return (state) => {
+    const length = state.output.length;
+    let repetitions = 0;
+    while (repetitions < max) {
+      const index = state.index;
+      if (!rule(state)) {
+        break;
+      }
+      repetitions += 1;
+      if (state.index === index) {
+        break;
+      }
+    }
+    if (repetitions < min) {
+      return false;
+    }
+    if (handler) {
+      _apply(state, length, handler);
+    }
+    return true;
+  };
+};
+
+const optional = (rule: Rule, handler?: (outputs: any[]) => any): Rule =>
+  repeat(rule, 0, 1, handler);
+const star = (rule: Rule, handler?: (outputs: any[]) => any): Rule =>
+  repeat(rule, 0, Infinity, handler);
+const plus = (rule: Rule, handler?: (outputs: any[]) => any): Rule =>
+  repeat(rule, 1, Infinity, handler);
+
+const lazy = (getter: () => Rule): Rule => {
+  let rule: Rule | undefined;
+  return (state) => (rule ??= getter())(state);
+};
+
+const parse = (input: string, rule: Rule): any[] => {
+  const state: State = { input, index: 0, output: [] };
+  if (rule(state) && state.index === input.length) {
+    return state.output;
+  }
+  throw new Error(`Failed to parse at index ${state.index}`);
+};
+
+// --- Node graph ---
+
+interface Node {
+  regex?: RegExp;
+  children: Node[];
+}
+
+const regex = (source: string): Node => ({ regex: new RegExp(source, "s"), children: [] });
+const slash = (): Node => ({ regex: new RegExp("[\\\\/]", "s"), children: [] });
+const alternation = (children: Node[]): Node => ({ children });
+
+const _pushToLeaves = (parent: Node, child: Node, handled: Set<Node>): void => {
+  if (handled.has(parent)) {
+    return;
+  }
+  handled.add(parent);
+  const { children } = parent;
+  if (children.length === 0) {
+    children.push(child);
+  } else {
+    for (const node of children) {
+      _pushToLeaves(node, child, handled);
+    }
+  }
+};
+
+const sequence = (nodes: Node[]): Node => {
+  if (nodes.length === 0) {
+    return alternation([]);
+  }
+  for (let i = nodes.length - 1; i >= 1; i--) {
+    _pushToLeaves(nodes[i - 1]!, nodes[i]!, new Set());
+  }
+  return nodes[0]!;
+};
+
+const getNodes = (root: Node): Node[] => {
+  const nodes = new Set<Node>();
+  const queue: Node[] = [root];
+  for (let i = 0; i < queue.length; i++) {
+    const node = queue[i]!;
+    if (nodes.has(node)) {
+      continue;
+    }
+    nodes.add(node);
+    for (const child of node.children) {
+      queue.push(child);
+    }
+  }
+  return [...nodes];
+};
+
+const nodeSourceCached = (node: Node, cache: Map<Node, string>): string => {
+  const cached = cache.get(node);
+  if (cached !== undefined) {
+    return cached;
+  }
+  let source = node.regex ? node.regex.source : "";
+  if (node.children.length > 0) {
+    const seen = new Set<string>();
+    for (const child of node.children) {
+      const childSource = nodeSourceCached(child, cache);
+      if (childSource) {
+        seen.add(childSource);
+      }
+    }
+    if (seen.size > 0) {
+      const children = [...seen];
+      source += children.length > 1 ? `(?:${children.join("|")})` : children[0];
+    }
+  }
+  cache.set(node, source);
+  return source;
+};
+
+// Compute sources leaf-to-root (BFS order reversed) so every child is already
+// cached when its parent is visited: recursion never nests deeper than one level,
+// which keeps pathological globs (e.g. thousands of escapes) from overflowing.
+const nodeSource = (root: Node): string => {
+  const cache = new Map<Node, string>();
+  const nodes = getNodes(root);
+  for (let i = nodes.length - 1; i >= 0; i--) {
+    nodeSourceCached(nodes[i]!, cache);
+  }
+  return cache.get(root) ?? "";
+};
+
+// --- Range expansion (`{1..3}`, `{a..c}`) ---
+
+const ALPHABET = "abcdefghijklmnopqrstuvwxyz";
+
+const int2alpha = (int: number): string => {
+  let alpha = "";
+  while (int > 0) {
+    alpha = ALPHABET[(int - 1) % 26] + alpha;
+    int = Math.floor((int - 1) / 26);
+  }
+  return alpha;
+};
+
+const alpha2int = (str: string): number => {
+  let int = 0;
+  for (const char of str) {
+    int = int * 26 + ALPHABET.indexOf(char) + 1;
+  }
+  return int;
+};
+
+const makeRangeInt = (start: number, end: number): number[] => {
+  if (end < start) {
+    return makeRangeInt(end, start);
+  }
+  const range: number[] = [];
+  while (start <= end) {
+    range.push(start++);
+  }
+  return range;
+};
+
+const makeRangePaddedInt = (start: number, end: number, paddingLength: number): string[] =>
+  makeRangeInt(start, end).map((int) => String(int).padStart(paddingLength, "0"));
+
+const makeRangeAlpha = (start: string, end: string): string[] =>
+  makeRangeInt(alpha2int(start), alpha2int(end)).map(int2alpha);
+
+// --- Normalize grammar (collapses redundant `**`) ---
+
+const identity = <T>(value: T): T => value;
+
+const NormalizeGrammar = star(
+  or([
+    match(/\\./, identity),
+    match(/\*\*\*+/, "*"),
+    match(/([^/{[(!])\*\*/, (_: string, $1: string) => `${$1}*`),
+    match(/(^|.)\*\*(?=[^*/)\]}])/, (_: string, $1: string) => `${$1}*`),
+    match(/./, identity),
+  ]),
+);
+
+const normalizeGlob = (glob: string): string => parse(glob, NormalizeGrammar).join("");
+
+// --- Parse grammar (glob -> node graph) ---
+
+const Escaped = match(/\\./, regex);
+const Escape = match(/[$.*+?^(){}[\]|]/, (char: string) => regex(`\\${char}`));
+const Slash = match(/[\\/]/, slash);
+const Passthrough = match(/[^$.*+?^(){}[\]|\\/]+/, regex);
+
+const NegationOdd = match(/^(?:!!)*!(.*)$/, (_: string, glob: string) =>
+  regex(`(?!^${compileGlob(glob).source}$).*?`),
+);
+const NegationEven = match(/^(!!)+/);
+const Negation = or([NegationOdd, NegationEven]);
+
+const StarStarBetween = match(/\/(\*\*\/)+/, () =>
+  alternation([sequence([slash(), regex(".+?"), slash()]), slash()]),
+);
+const StarStarStart = match(/^(\*\*\/)+/, () =>
+  alternation([regex("^"), sequence([regex(".*?"), slash()])]),
+);
+const StarStarEnd = match(/\/(\*\*)$/, () =>
+  alternation([sequence([slash(), regex(".*?")]), regex("$")]),
+);
+const StarStarNone = match(/\*\*/, () => regex(".*?"));
+const StarStar = or([StarStarBetween, StarStarStart, StarStarEnd, StarStarNone]);
+
+const StarDouble = match(/\*\/(?!\*\*\/|\*$)/, () => sequence([regex("[^\\\\/]*?"), slash()]));
+const StarSingle = match(/\*/, () => regex("[^\\\\/]*"));
+const Star = or([StarDouble, StarSingle]);
+
+const Question = match("?", () => regex("[^\\\\/]"));
+
+const ClassOpen = match("[", identity);
+const ClassClose = match("]", identity);
+const ClassNegation = match(/[!^]/, "^\\\\/");
+const ClassRange = match(/[a-z]-[a-z]|[0-9]-[0-9]/i, identity);
+const ClassEscaped = match(/\\./, identity);
+const ClassEscape = match(/[$.*+?^(){}[|]/, (char: string) => `\\${char}`);
+const ClassSlash = match(/[\\/]/, "\\\\/");
+const ClassPassthrough = match(/[^$.*+?^(){}[\]|\\/]+/, identity);
+const ClassValue = or([ClassEscaped, ClassEscape, ClassSlash, ClassRange, ClassPassthrough]);
+const Class = and([ClassOpen, optional(ClassNegation), star(ClassValue), ClassClose], (_) =>
+  regex(_.join("")),
+);
+
+const RangeOpen = match("{", "(?:");
+const RangeClose = match("}", ")");
+const RangeNumeric = match(/(\d+)\.\.(\d+)/, (_: string, $1: string, $2: string) =>
+  makeRangePaddedInt(+$1, +$2, Math.min($1.length, $2.length)).join("|"),
+);
+const RangeAlphaLower = match(/([a-z]+)\.\.([a-z]+)/, (_: string, $1: string, $2: string) =>
+  makeRangeAlpha($1, $2).join("|"),
+);
+const RangeAlphaUpper = match(/([A-Z]+)\.\.([A-Z]+)/, (_: string, $1: string, $2: string) =>
+  makeRangeAlpha($1.toLowerCase(), $2.toLowerCase()).join("|").toUpperCase(),
+);
+const RangeValue = or([RangeNumeric, RangeAlphaLower, RangeAlphaUpper]);
+const Range = and([RangeOpen, RangeValue, RangeClose], (_) => regex(_.join("")));
+
+const BracesOpen = match("{");
+const BracesClose = match("}");
+const BracesComma = match(",");
+const BracesEscaped = match(/\\./, regex);
+const BracesEscape = match(/[$.*+?^(){[\]|]/, (char: string) => regex(`\\${char}`));
+const BracesSlash = match(/[\\/]/, slash);
+const BracesPassthrough = match(/[^$.*+?^(){}[\]|\\/,]+/, regex);
+const BracesNested = lazy(() => Braces);
+const BracesEmptyValue = match("", () => regex("(?:)"));
+const BracesFullValue = plus(
+  or([
+    StarStar,
+    Star,
+    Question,
+    Class,
+    Range,
+    BracesNested,
+    BracesEscaped,
+    BracesEscape,
+    BracesSlash,
+    BracesPassthrough,
+  ]),
+  sequence,
+);
+const BracesValue = or([BracesFullValue, BracesEmptyValue]);
+const Braces: Rule = and(
+  [BracesOpen, optional(and([BracesValue, star(and([BracesComma, BracesValue]))])), BracesClose],
+  alternation,
+);
+
+const Grammar = star(
+  or([
+    Negation,
+    StarStar,
+    Star,
+    Question,
+    Class,
+    Range,
+    Braces,
+    Escaped,
+    Escape,
+    Slash,
+    Passthrough,
+  ]),
+  sequence,
+);
+
+// --- Compilation ---
+
+const _cache = new Map<string, RegExp>();
+
+function compileGlob(glob: string): RegExp {
+  let re = _cache.get(glob);
+  if (re === undefined) {
+    const node: Node = parse(normalizeGlob(glob), Grammar)[0];
+    const source = nodeSource(node);
+    re = new RegExp(`^(?:${source})[\\\\/]?$`, "s");
+    _cache.set(glob, re);
+  }
+  return re;
+}
+
+const compileGlobs = (globs: string[]): RegExp => {
+  const source = globs.map((glob) => compileGlob(glob).source).join("|") || "$^";
+  return new RegExp(source, "s");
+};
+
+/**
+ * Compile a glob (or list of globs) to a `RegExp` and test it against `path`.
+ */
+export const matchGlob = (glob: string | string[], path: string): boolean => {
+  const re = typeof glob === "string" ? compileGlob(glob) : compileGlobs(glob);
+  return re.test(path);
+};

--- a/src/_glob.ts
+++ b/src/_glob.ts
@@ -441,15 +441,29 @@ const Grammar = /* @__PURE__ */ star(
 
 // --- Compilation ---
 
+// Bounded LRU cache so long-running processes matching many distinct globs
+// don't grow memory without limit. A `Map` preserves insertion order, so the
+// least-recently-used entry is always the first key.
+const CACHE_MAX = 1000;
 const _cache = /* @__PURE__ */ new Map<string, RegExp>();
 
 function compileGlob(glob: string): RegExp {
-  let re = _cache.get(glob);
-  if (re === undefined) {
-    const node: Node = parse(normalizeGlob(glob), Grammar)[0];
-    const source = nodeSource(node);
-    re = new RegExp(`^(?:${source})[\\\\/]?$`, "s");
-    _cache.set(glob, re);
+  const cached = _cache.get(glob);
+  if (cached !== undefined) {
+    // Re-insert to mark as most-recently-used.
+    _cache.delete(glob);
+    _cache.set(glob, cached);
+    return cached;
+  }
+  const node: Node = parse(normalizeGlob(glob), Grammar)[0];
+  const source = nodeSource(node);
+  const re = new RegExp(`^(?:${source})[\\\\/]?$`, "s");
+  _cache.set(glob, re);
+  if (_cache.size > CACHE_MAX) {
+    const oldest = _cache.keys().next().value;
+    if (oldest !== undefined) {
+      _cache.delete(oldest);
+    }
   }
   return re;
 }

--- a/src/_glob.ts
+++ b/src/_glob.ts
@@ -296,13 +296,13 @@ const makeRangeAlpha = (start: string, end: string): string[] =>
 
 const identity = <T>(value: T): T => value;
 
-const NormalizeGrammar = star(
-  or([
-    match(/\\./, identity),
-    match(/\*\*\*+/, "*"),
-    match(/([^/{[(!])\*\*/, (_: string, $1: string) => `${$1}*`),
-    match(/(^|.)\*\*(?=[^*/)\]}])/, (_: string, $1: string) => `${$1}*`),
-    match(/./, identity),
+const NormalizeGrammar = /* @__PURE__ */ star(
+  /* @__PURE__ */ or([
+    /* @__PURE__ */ match(/\\./, identity),
+    /* @__PURE__ */ match(/\*\*\*+/, "*"),
+    /* @__PURE__ */ match(/([^/{[(!])\*\*/, (_: string, $1: string) => `${$1}*`),
+    /* @__PURE__ */ match(/(^|.)\*\*(?=[^*/)\]}])/, (_: string, $1: string) => `${$1}*`),
+    /* @__PURE__ */ match(/./, identity),
   ]),
 );
 
@@ -310,73 +310,90 @@ const normalizeGlob = (glob: string): string => parse(glob, NormalizeGrammar).jo
 
 // --- Parse grammar (glob -> node graph) ---
 
-const Escaped = match(/\\./, regex);
-const Escape = match(/[$.*+?^(){}[\]|]/, (char: string) => regex(`\\${char}`));
-const Slash = match(/[\\/]/, slash);
-const Passthrough = match(/[^$.*+?^(){}[\]|\\/]+/, regex);
+const Escaped = /* @__PURE__ */ match(/\\./, regex);
+const Escape = /* @__PURE__ */ match(/[$.*+?^(){}[\]|]/, (char: string) => regex(`\\${char}`));
+const Slash = /* @__PURE__ */ match(/[\\/]/, slash);
+const Passthrough = /* @__PURE__ */ match(/[^$.*+?^(){}[\]|\\/]+/, regex);
 
-const NegationOdd = match(/^(?:!!)*!(.*)$/, (_: string, glob: string) =>
+const NegationOdd = /* @__PURE__ */ match(/^(?:!!)*!(.*)$/, (_: string, glob: string) =>
   regex(`(?!^${compileGlob(glob).source}$).*?`),
 );
-const NegationEven = match(/^(!!)+/);
-const Negation = or([NegationOdd, NegationEven]);
+const NegationEven = /* @__PURE__ */ match(/^(!!)+/);
+const Negation = /* @__PURE__ */ or([NegationOdd, NegationEven]);
 
-const StarStarBetween = match(/\/(\*\*\/)+/, () =>
+const StarStarBetween = /* @__PURE__ */ match(/\/(\*\*\/)+/, () =>
   alternation([sequence([slash(), regex(".+?"), slash()]), slash()]),
 );
-const StarStarStart = match(/^(\*\*\/)+/, () =>
+const StarStarStart = /* @__PURE__ */ match(/^(\*\*\/)+/, () =>
   alternation([regex("^"), sequence([regex(".*?"), slash()])]),
 );
-const StarStarEnd = match(/\/(\*\*)$/, () =>
+const StarStarEnd = /* @__PURE__ */ match(/\/(\*\*)$/, () =>
   alternation([sequence([slash(), regex(".*?")]), regex("$")]),
 );
-const StarStarNone = match(/\*\*/, () => regex(".*?"));
-const StarStar = or([StarStarBetween, StarStarStart, StarStarEnd, StarStarNone]);
+const StarStarNone = /* @__PURE__ */ match(/\*\*/, () => regex(".*?"));
+const StarStar = /* @__PURE__ */ or([StarStarBetween, StarStarStart, StarStarEnd, StarStarNone]);
 
-const StarDouble = match(/\*\/(?!\*\*\/|\*$)/, () => sequence([regex("[^\\\\/]*?"), slash()]));
-const StarSingle = match(/\*/, () => regex("[^\\\\/]*"));
-const Star = or([StarDouble, StarSingle]);
+const StarDouble = /* @__PURE__ */ match(/\*\/(?!\*\*\/|\*$)/, () =>
+  sequence([regex("[^\\\\/]*?"), slash()]),
+);
+const StarSingle = /* @__PURE__ */ match(/\*/, () => regex("[^\\\\/]*"));
+const Star = /* @__PURE__ */ or([StarDouble, StarSingle]);
 
-const Question = match("?", () => regex("[^\\\\/]"));
+const Question = /* @__PURE__ */ match("?", () => regex("[^\\\\/]"));
 
-const ClassOpen = match("[", identity);
-const ClassClose = match("]", identity);
-const ClassNegation = match(/[!^]/, "^\\\\/");
-const ClassRange = match(/[a-z]-[a-z]|[0-9]-[0-9]/i, identity);
-const ClassEscaped = match(/\\./, identity);
-const ClassEscape = match(/[$.*+?^(){}[|]/, (char: string) => `\\${char}`);
-const ClassSlash = match(/[\\/]/, "\\\\/");
-const ClassPassthrough = match(/[^$.*+?^(){}[\]|\\/]+/, identity);
-const ClassValue = or([ClassEscaped, ClassEscape, ClassSlash, ClassRange, ClassPassthrough]);
-const Class = and([ClassOpen, optional(ClassNegation), star(ClassValue), ClassClose], (_) =>
-  regex(_.join("")),
+const ClassOpen = /* @__PURE__ */ match("[", identity);
+const ClassClose = /* @__PURE__ */ match("]", identity);
+const ClassNegation = /* @__PURE__ */ match(/[!^]/, "^\\\\/");
+const ClassRange = /* @__PURE__ */ match(/[a-z]-[a-z]|[0-9]-[0-9]/i, identity);
+const ClassEscaped = /* @__PURE__ */ match(/\\./, identity);
+const ClassEscape = /* @__PURE__ */ match(/[$.*+?^(){}[|]/, (char: string) => `\\${char}`);
+const ClassSlash = /* @__PURE__ */ match(/[\\/]/, "\\\\/");
+const ClassPassthrough = /* @__PURE__ */ match(/[^$.*+?^(){}[\]|\\/]+/, identity);
+const ClassValue = /* @__PURE__ */ or([
+  ClassEscaped,
+  ClassEscape,
+  ClassSlash,
+  ClassRange,
+  ClassPassthrough,
+]);
+const Class = /* @__PURE__ */ and(
+  [
+    ClassOpen,
+    /* @__PURE__ */ optional(ClassNegation),
+    /* @__PURE__ */ star(ClassValue),
+    ClassClose,
+  ],
+  (_) => regex(_.join("")),
 );
 
-const RangeOpen = match("{", "(?:");
-const RangeClose = match("}", ")");
-const RangeNumeric = match(/(\d+)\.\.(\d+)/, (_: string, $1: string, $2: string) =>
+const RangeOpen = /* @__PURE__ */ match("{", "(?:");
+const RangeClose = /* @__PURE__ */ match("}", ")");
+const RangeNumeric = /* @__PURE__ */ match(/(\d+)\.\.(\d+)/, (_: string, $1: string, $2: string) =>
   makeRangePaddedInt(+$1, +$2, Math.min($1.length, $2.length)).join("|"),
 );
-const RangeAlphaLower = match(/([a-z]+)\.\.([a-z]+)/, (_: string, $1: string, $2: string) =>
-  makeRangeAlpha($1, $2).join("|"),
+const RangeAlphaLower = /* @__PURE__ */ match(
+  /([a-z]+)\.\.([a-z]+)/,
+  (_: string, $1: string, $2: string) => makeRangeAlpha($1, $2).join("|"),
 );
-const RangeAlphaUpper = match(/([A-Z]+)\.\.([A-Z]+)/, (_: string, $1: string, $2: string) =>
-  makeRangeAlpha($1.toLowerCase(), $2.toLowerCase()).join("|").toUpperCase(),
+const RangeAlphaUpper = /* @__PURE__ */ match(
+  /([A-Z]+)\.\.([A-Z]+)/,
+  (_: string, $1: string, $2: string) =>
+    makeRangeAlpha($1.toLowerCase(), $2.toLowerCase()).join("|").toUpperCase(),
 );
-const RangeValue = or([RangeNumeric, RangeAlphaLower, RangeAlphaUpper]);
-const Range = and([RangeOpen, RangeValue, RangeClose], (_) => regex(_.join("")));
+const RangeValue = /* @__PURE__ */ or([RangeNumeric, RangeAlphaLower, RangeAlphaUpper]);
+const Range = /* @__PURE__ */ and([RangeOpen, RangeValue, RangeClose], (_) => regex(_.join("")));
 
-const BracesOpen = match("{");
-const BracesClose = match("}");
-const BracesComma = match(",");
-const BracesEscaped = match(/\\./, regex);
-const BracesEscape = match(/[$.*+?^(){[\]|]/, (char: string) => regex(`\\${char}`));
-const BracesSlash = match(/[\\/]/, slash);
-const BracesPassthrough = match(/[^$.*+?^(){}[\]|\\/,]+/, regex);
-const BracesNested = lazy(() => Braces);
-const BracesEmptyValue = match("", () => regex("(?:)"));
-const BracesFullValue = plus(
-  or([
+const BracesOpen = /* @__PURE__ */ match("{");
+const BracesClose = /* @__PURE__ */ match("}");
+const BracesComma = /* @__PURE__ */ match(",");
+const BracesEscaped = /* @__PURE__ */ match(/\\./, regex);
+const BracesEscape = /* @__PURE__ */ match(/[$.*+?^(){[\]|]/, (char: string) => regex(`\\${char}`));
+const BracesSlash = /* @__PURE__ */ match(/[\\/]/, slash);
+const BracesPassthrough = /* @__PURE__ */ match(/[^$.*+?^(){}[\]|\\/,]+/, regex);
+const BracesNested = /* @__PURE__ */ lazy(() => Braces);
+const BracesEmptyValue = /* @__PURE__ */ match("", () => regex("(?:)"));
+const BracesFullValue = /* @__PURE__ */ plus(
+  /* @__PURE__ */ or([
     StarStar,
     Star,
     Question,
@@ -390,14 +407,23 @@ const BracesFullValue = plus(
   ]),
   sequence,
 );
-const BracesValue = or([BracesFullValue, BracesEmptyValue]);
-const Braces: Rule = and(
-  [BracesOpen, optional(and([BracesValue, star(and([BracesComma, BracesValue]))])), BracesClose],
+const BracesValue = /* @__PURE__ */ or([BracesFullValue, BracesEmptyValue]);
+const Braces: Rule = /* @__PURE__ */ and(
+  [
+    BracesOpen,
+    /* @__PURE__ */ optional(
+      /* @__PURE__ */ and([
+        BracesValue,
+        /* @__PURE__ */ star(/* @__PURE__ */ and([BracesComma, BracesValue])),
+      ]),
+    ),
+    BracesClose,
+  ],
   alternation,
 );
 
-const Grammar = star(
-  or([
+const Grammar = /* @__PURE__ */ star(
+  /* @__PURE__ */ or([
     Negation,
     StarStar,
     Star,
@@ -415,7 +441,7 @@ const Grammar = star(
 
 // --- Compilation ---
 
-const _cache = new Map<string, RegExp>();
+const _cache = /* @__PURE__ */ new Map<string, RegExp>();
 
 function compileGlob(glob: string): RegExp {
   let re = _cache.get(glob);

--- a/src/_internal.ts
+++ b/src/_internal.ts
@@ -10,12 +10,7 @@ export function normalizeWindowsPath(input = "") {
   }
 
   const driveLetter = normalized[0];
-  if (
-    normalized[1] === ":" &&
-    normalized[2] === "/" &&
-    driveLetter >= "a" &&
-    driveLetter <= "z"
-  ) {
+  if (normalized[1] === ":" && normalized[2] === "/" && driveLetter >= "a" && driveLetter <= "z") {
     normalized = driveLetter.toUpperCase() + normalized.slice(1);
   }
 

--- a/src/_internal.ts
+++ b/src/_internal.ts
@@ -10,7 +10,7 @@ export function normalizeWindowsPath(input = "") {
   }
 
   const driveLetter = normalized[0];
-  if (normalized[1] === ":" && normalized[2] === "/" && driveLetter >= "a" && driveLetter <= "z") {
+  if (driveLetter && normalized[1] === ":" && normalized[2] === "/" && driveLetter >= "a" && driveLetter <= "z") {
     normalized = driveLetter.toUpperCase() + normalized.slice(1);
   }
 

--- a/src/_internal.ts
+++ b/src/_internal.ts
@@ -10,7 +10,13 @@ export function normalizeWindowsPath(input = "") {
   }
 
   const driveLetter = normalized[0];
-  if (driveLetter && normalized[1] === ":" && normalized[2] === "/" && driveLetter >= "a" && driveLetter <= "z") {
+  if (
+    driveLetter &&
+    normalized[1] === ":" &&
+    normalized[2] === "/" &&
+    driveLetter >= "a" &&
+    driveLetter <= "z"
+  ) {
     normalized = driveLetter.toUpperCase() + normalized.slice(1);
   }
 

--- a/src/_path.ts
+++ b/src/_path.ts
@@ -8,8 +8,7 @@ Check LICENSE file
 
 import type path from "node:path";
 
-import zeptomatch from "zeptomatch";
-
+import { matchGlob } from "./_glob";
 import { normalizeWindowsPath } from "./_internal";
 
 const _UNC_REGEX = /^[/\\]{2}/;
@@ -299,5 +298,5 @@ export const parse: typeof path.parse = function (p) {
  * @param pattern The glob to check the path against.
  */
 export const matchesGlob = (path: string, pattern: string | string[]): boolean => {
-  return zeptomatch(pattern, normalize(path));
+  return matchGlob(pattern, normalize(path));
 };

--- a/test/glob.spec.ts
+++ b/test/glob.spec.ts
@@ -20,9 +20,19 @@ import { describe as vDescribe, it as vIt, expect } from "vitest";
 
 import { matchGlob } from "../src/_glob";
 
-const isMatch = matchGlob;
+// The vendored suite exercises features (e.g. `partial`) not ported to
+// `matchGlob`; accept and ignore an optional options arg so those (skipped)
+// cases still type-check.
+const isMatch = (
+  glob: string | string[],
+  path: string,
+  _options?: { partial?: boolean },
+): boolean => matchGlob(glob, path);
 
-const compile = () => {
+const compile = (
+  _glob?: string | string[],
+  _options?: { partial?: boolean },
+): unknown => {
   throw new Error("compile() is not ported");
 };
 
@@ -33,7 +43,11 @@ type Assert = {
   not: (a: unknown, b: unknown) => void;
 };
 
-const describe = (name: string, fn: (it: any) => void): void => {
+type Register = ((label: string, body: (t: Assert) => void) => void) & {
+  skip: (label: string, body: (t: Assert) => void) => void;
+};
+
+const describe = (name: string, fn: (it: Register) => void): void => {
   vDescribe(name, () => {
     const register = (label: string, body: (t: Assert) => void) => {
       if (/partial|memoization/.test(label)) {

--- a/test/glob.spec.ts
+++ b/test/glob.spec.ts
@@ -1,0 +1,3140 @@
+// Behavioral test suite vendored from zeptomatch's `test/index.js`:
+//  - https://github.com/fabiospampinato/zeptomatch/blob/master/test/index.js
+//
+// Adapted to run against the ported `matchGlob` implementation. The `partial`
+// and `memoization` blocks are skipped as those features are not used by pathe.
+//
+// The MIT License (MIT)
+// Copyright (c) 2023-present Fabio Spampinato
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+import { describe as vDescribe, it as vIt, expect } from "vitest";
+
+import { matchGlob } from "../src/_glob";
+
+const isMatch = matchGlob;
+
+const compile = () => {
+  throw new Error("compile() is not ported");
+};
+
+type Assert = {
+  true: (v: unknown) => void;
+  false: (v: unknown) => void;
+  is: (a: unknown, b: unknown) => void;
+  not: (a: unknown, b: unknown) => void;
+};
+
+const describe = (name: string, fn: (it: any) => void): void => {
+  vDescribe(name, () => {
+    const register = (label: string, body: (t: Assert) => void) => {
+      if (/partial|memoization/.test(label)) {
+        vIt.skip(label, () => {});
+        return;
+      }
+      vIt(label, () => {
+        body({
+          true: (v) => expect(v).toBe(true),
+          false: (v) => expect(v).toBe(false),
+          is: (a, b) => expect(a).toBe(b),
+          not: (a, b) => expect(a).not.toBe(b),
+        });
+      });
+    };
+    register.skip = (label: string, _body: (t: Assert) => void) => vIt.skip(label, () => {});
+    fn(register);
+  });
+};
+
+describe("Zeptomatch", (it) => {
+  // Native tests
+
+  it("native", (t) => {
+    t.true(isMatch([], ""));
+    t.true(!isMatch([], "a"));
+
+    t.true(isMatch(["*.md", "*.js"], "foo.md"));
+    t.true(isMatch(["*.md", "*.js"], "foo.js"));
+    t.true(!isMatch(["*.md", "*.js"], "foo.txt"));
+
+    t.true(!isMatch("*/**foo", "foo/bar/foo"));
+    t.true(isMatch("*/**foo", "foo/barfoo"));
+
+    t.true(!isMatch("*/**foo", "foo\\bar\\foo"));
+    t.true(isMatch("*/**foo", "foo\\barfoo"));
+
+    t.true(!isMatch("*.js", "abcd"));
+    t.true(isMatch("*.js", "a.js"));
+    t.true(!isMatch("*.js", "a.md"));
+    t.true(!isMatch("*.js", "a/b.js"));
+
+    t.true(isMatch("{a{a{a,b},b{a,b}},b{a{a,b},b{a,b}}}", "aaa"));
+    t.true(isMatch("{a{a{a,b},b{a,b}},b{a{a,b},b{a,b}}}", "aab"));
+    t.true(isMatch("{a{a{a,b},b{a,b}},b{a{a,b},b{a,b}}}", "aba"));
+    t.true(isMatch("{a{a{a,b},b{a,b}},b{a{a,b},b{a,b}}}", "abb"));
+    t.true(isMatch("{a{a{a,b},b{a,b}},b{a{a,b},b{a,b}}}", "baa"));
+    t.true(isMatch("{a{a{a,b},b{a,b}},b{a{a,b},b{a,b}}}", "bab"));
+    t.true(isMatch("{a{a{a,b},b{a,b}},b{a{a,b},b{a,b}}}", "bba"));
+    t.true(isMatch("{a{a{a,b},b{a,b}},b{a{a,b},b{a,b}}}", "bbb"));
+    t.true(!isMatch("{a{a{a,b},b{a,b}},b{a{a,b},b{a,b}}}", "a"));
+    t.true(!isMatch("{a{a{a,b},b{a,b}},b{a{a,b},b{a,b}}}", "b"));
+    t.true(!isMatch("{a{a{a,b},b{a,b}},b{a{a,b},b{a,b}}}", "aa"));
+    t.true(!isMatch("{a{a{a,b},b{a,b}},b{a{a,b},b{a,b}}}", "bb"));
+  });
+
+  it("native_grammar_full", (t) => {
+    // Escaped
+    t.true(isMatch("\\n", "\n"));
+    t.true(isMatch("\\(", "("));
+    // Escape
+    t.true(isMatch("(", "("));
+    // Slash
+    t.true(isMatch("/", "/"));
+    t.true(isMatch("/", "\\"));
+    t.true(isMatch("\\", "/"));
+    t.true(isMatch("\\", "\\"));
+    // Passthrough
+    t.true(isMatch("abc", "abc"));
+
+    // Negation
+    t.true(isMatch("!foo", "bar"));
+    t.false(isMatch("!foo", "foo"));
+    t.true(isMatch("!!foo", "foo"));
+    t.false(isMatch("!!!foo", "foo"));
+
+    // StarStar
+    t.true(isMatch("**", "foo/bar"));
+
+    // Star
+    t.true(isMatch("*", "abc"));
+    t.true(isMatch("*.js", "abc.js"));
+
+    // Question
+    t.true(isMatch("?", "a"));
+    t.false(isMatch("?", ""));
+    t.false(isMatch("?", "/"));
+    t.false(isMatch("?", "\\"));
+
+    // Class
+    t.true(isMatch("[a-z]", "a"));
+    t.true(isMatch("[A-Z]", "A"));
+    t.true(isMatch("[a-zA-Z]", "a"));
+    t.true(isMatch("[a-zA-Z]", "A"));
+    t.true(isMatch("[0-9]", "0"));
+    t.true(isMatch("[a-z][0-9]", "a0"));
+    t.true(isMatch("[^a-z][^0-9]", "0a"));
+    t.false(isMatch("[a-z]", "A"));
+    t.false(isMatch("[A-Z]", "a"));
+
+    // Range
+    t.true(isMatch("{1..9}", "1"));
+    t.true(isMatch("{a..z}", "a"));
+    t.true(isMatch("{A..Z}", "A"));
+    t.true(isMatch("{A..Z}{1..9}", "A1"));
+    t.true(isMatch("{1..9}{A..Z}", "1A"));
+    t.false(isMatch("{a..z}", "A"));
+    t.false(isMatch("{A..Z}", "a"));
+
+    // Braces
+    t.true(isMatch("{foo,bar}", "foo"));
+    t.true(isMatch("{foo,bar}", "bar"));
+    t.true(isMatch("{}", ""));
+    t.true(isMatch("{,}", ""));
+    t.true(isMatch("{,foo}", ""));
+    t.true(isMatch("{,foo}", "foo"));
+    t.false(isMatch("{foo,bar}", ""));
+    t.false(isMatch("{foo,bar}", "foobar"));
+    t.true(isMatch("{foo/bar,baz/qux}", "foo/bar"));
+    t.true(isMatch("{foo/bar,baz/qux}", "baz/qux"));
+    t.false(isMatch("{foo/bar,baz/qux}", "foo/qux"));
+    t.false(isMatch("{foo/bar,baz/qux}", "baz/bar"));
+  });
+
+  it("native_grammar_partial", (t) => {
+    // Escaped
+    t.false(isMatch("\\n\\n", "\n", { partial: true }));
+    t.false(isMatch("\\(\\(", "(", { partial: true }));
+    // Escape
+    t.false(isMatch("((", "(", { partial: true }));
+    // Slash
+    t.true(isMatch("//", "/", { partial: true }));
+    t.true(isMatch("//", "\\", { partial: true }));
+    // Passthrough
+    t.false(isMatch("abc", "", { partial: true }));
+    t.false(isMatch("abc", "a", { partial: true }));
+    t.false(isMatch("abc", "ab", { partial: true }));
+    t.true(isMatch("abc", "abc", { partial: true }));
+
+    // Negation
+    t.true(isMatch("!foo/bar", "bar", { partial: true }));
+    t.false(isMatch("!foo", "foo", { partial: true }));
+    t.true(isMatch("!!foo", "foo", { partial: true }));
+    t.false(isMatch("!!!foo", "foo", { partial: true }));
+
+    // StarStar
+    t.true(isMatch("**", "", { partial: true }));
+    t.true(isMatch("**", "foo", { partial: true }));
+    t.true(isMatch("**", "foo/", { partial: true }));
+    t.true(isMatch("**", "foo/bar", { partial: true }));
+    t.true(isMatch("**", "foo/bar/", { partial: true }));
+
+    // Star
+    t.true(isMatch("*", "", { partial: true }));
+    t.true(isMatch("*", "abc", { partial: true }));
+    t.true(isMatch("*.js", "abc.js", { partial: true }));
+    t.false(isMatch("*.js", "abc", { partial: true }));
+
+    // Question
+    t.false(isMatch("a?b", "a", { partial: true }));
+    t.false(isMatch("a?b", "ab", { partial: true }));
+    t.true(isMatch("a?b", "abb", { partial: true }));
+    t.false(isMatch("a?b", "abc", { partial: true }));
+
+    // Class
+    t.false(isMatch("[a-z][a-z]", "a", { partial: true }));
+    t.false(isMatch("[A-Z][A-Z]", "A", { partial: true }));
+    t.false(isMatch("[a-zA-Z][a-zA-Z]", "a", { partial: true }));
+    t.false(isMatch("[a-zA-Z][a-zA-Z]", "A", { partial: true }));
+    t.false(isMatch("[0-9][0-9]", "0", { partial: true }));
+    t.false(isMatch("[a-z][0-9][a-z][0-9]", "a0", { partial: true }));
+    t.false(isMatch("[^a-z][^0-9][^a-z][^0-9]", "0a", { partial: true }));
+
+    // Range
+    t.false(isMatch("{1..9}{1..9}", "1", { partial: true }));
+    t.false(isMatch("{a..z}{a..z}", "a", { partial: true }));
+    t.false(isMatch("{A..Z}{A..Z}", "A", { partial: true }));
+    t.false(isMatch("{A..Z}{1..9}{A..Z}{1..9}", "A1", { partial: true }));
+    t.false(isMatch("{1..9}{A..Z}{1..9}{A..Z}", "1A", { partial: true }));
+
+    // Braces
+    t.false(isMatch("{foo,bar}baz", "foo", { partial: true }));
+    t.false(isMatch("{foo,bar}baz", "bar", { partial: true }));
+    t.false(isMatch("{foo,bar}baz", "f", { partial: true }));
+    t.false(isMatch("{foo,bar}baz", "b", { partial: true }));
+
+    t.true(isMatch("{foo/bar,baz/qux}", "foo", { partial: true }));
+    t.true(isMatch("{foo/bar,baz/qux}", "foo/", { partial: true }));
+    t.true(isMatch("{foo/bar,baz/qux}", "baz", { partial: true }));
+    t.true(isMatch("{foo/bar,baz/qux}", "baz/", { partial: true }));
+    t.false(isMatch("{foo/bar,baz/qux}", "foo/qux", { partial: true }));
+    t.false(isMatch("{foo/bar,baz/qux}", "baz/bar", { partial: true }));
+  });
+
+  it("native_memoization", (t) => {
+    const glob = "foo";
+    const re1 = compile(glob);
+    const re2 = compile(glob);
+    const re3 = compile(glob, { partial: true });
+    const re4 = compile(glob, { partial: true });
+    t.is(re1, re2);
+    t.is(re3, re4);
+    t.not(re1, re3);
+
+    const globs = ["foo", "bar"];
+    const re5 = compile(globs);
+    const re6 = compile(globs);
+    const re7 = compile(globs, { partial: true });
+    const re8 = compile(globs, { partial: true });
+    t.is(re5, re6);
+    t.is(re7, re8);
+    t.not(re5, re8);
+  });
+
+  it("native_partial_0", (t) => {
+    const glob = "/*/b/x/y/z";
+
+    t.true(isMatch(glob, "/a/b", { partial: true }));
+    t.false(isMatch(glob, "/a/b"));
+    t.false(isMatch(glob, "/a/b/c", { partial: true }));
+  });
+
+  it("native_partial_1", (t) => {
+    const glob = "foo/**/{bar/baz,qux}/*.js";
+
+    // Partial
+
+    t.false(isMatch(glob, "", { partial: true }));
+    t.true(isMatch(glob, "foo", { partial: true }));
+    t.true(isMatch(glob, "foo/", { partial: true }));
+
+    t.true(isMatch(glob, "foo/bar", { partial: true }));
+    t.true(isMatch(glob, "foo/bar/", { partial: true }));
+    t.true(isMatch(glob, "foo/qux", { partial: true }));
+    t.true(isMatch(glob, "foo/qux/", { partial: true }));
+
+    t.true(isMatch(glob, "foo/bar_", { partial: true }));
+    t.true(isMatch(glob, "foo/bar_", { partial: true }));
+    t.true(isMatch(glob, "foo/bar/_", { partial: true }));
+    t.true(isMatch(glob, "foo/qux_", { partial: true }));
+    t.true(isMatch(glob, "foo/qux/_", { partial: true }));
+
+    // Full
+
+    t.false(isMatch(glob, ""));
+    t.false(isMatch(glob, "foo"));
+    t.false(isMatch(glob, "foo/"));
+
+    t.false(isMatch(glob, "foo/bar"));
+    t.false(isMatch(glob, "foo/bar/"));
+    t.false(isMatch(glob, "foo/qux"));
+    t.false(isMatch(glob, "foo/qux/"));
+
+    t.false(isMatch(glob, "foo/bar_"));
+    t.false(isMatch(glob, "foo/bar/_"));
+    t.false(isMatch(glob, "foo/qux_"));
+    t.false(isMatch(glob, "foo/qux/_"));
+  });
+
+  it("native_partial_2", (t) => {
+    const glob = "foo/*/{bar/baz,qux}/*.js";
+
+    // Partial
+
+    t.false(isMatch(glob, "", { partial: true }));
+    t.true(isMatch(glob, "foo", { partial: true }));
+    t.true(isMatch(glob, "foo/", { partial: true }));
+
+    t.true(isMatch(glob, "foo/bar", { partial: true }));
+    t.true(isMatch(glob, "foo/bar/", { partial: true }));
+    t.true(isMatch(glob, "foo/qux", { partial: true }));
+    t.true(isMatch(glob, "foo/qux/", { partial: true }));
+
+    t.true(isMatch(glob, "foo/bar_", { partial: true }));
+    t.true(isMatch(glob, "foo/bar_", { partial: true }));
+    t.false(isMatch(glob, "foo/bar/_", { partial: true }));
+    t.true(isMatch(glob, "foo/qux_", { partial: true }));
+    t.false(isMatch(glob, "foo/qux/_", { partial: true }));
+
+    // Full
+
+    t.false(isMatch(glob, ""));
+    t.false(isMatch(glob, "foo"));
+    t.false(isMatch(glob, "foo/"));
+
+    t.false(isMatch(glob, "foo/bar"));
+    t.false(isMatch(glob, "foo/bar/"));
+    t.false(isMatch(glob, "foo/qux"));
+    t.false(isMatch(glob, "foo/qux/"));
+
+    t.false(isMatch(glob, "foo/bar_"));
+    t.false(isMatch(glob, "foo/bar/_"));
+    t.false(isMatch(glob, "foo/qux_"));
+    t.false(isMatch(glob, "foo/qux/_"));
+  });
+
+  it("native_partial_3", (t) => {
+    const glob = "foo/{bar/baz,qux}/*.js";
+
+    // Partial
+
+    t.false(isMatch(glob, "", { partial: true }));
+    t.true(isMatch(glob, "foo", { partial: true }));
+    t.true(isMatch(glob, "foo/", { partial: true }));
+
+    t.true(isMatch(glob, "foo/bar", { partial: true }));
+    t.true(isMatch(glob, "foo/bar/", { partial: true }));
+    t.true(isMatch(glob, "foo/qux", { partial: true }));
+    t.true(isMatch(glob, "foo/qux/", { partial: true }));
+
+    t.false(isMatch(glob, "foo/bar_", { partial: true }));
+    t.false(isMatch(glob, "foo/bar_", { partial: true }));
+    t.false(isMatch(glob, "foo/bar/_", { partial: true }));
+    t.false(isMatch(glob, "foo/bar/baz/_", { partial: true }));
+    t.false(isMatch(glob, "foo/qux_", { partial: true }));
+    t.false(isMatch(glob, "foo/qux/_", { partial: true }));
+
+    // Full
+
+    t.false(isMatch(glob, ""));
+    t.false(isMatch(glob, "foo"));
+    t.false(isMatch(glob, "foo/"));
+
+    t.false(isMatch(glob, "foo/bar"));
+    t.false(isMatch(glob, "foo/bar/"));
+    t.false(isMatch(glob, "foo/qux"));
+    t.false(isMatch(glob, "foo/qux/"));
+
+    t.false(isMatch(glob, "foo/bar_"));
+    t.false(isMatch(glob, "foo/bar/_"));
+    t.false(isMatch(glob, "foo/qux_"));
+    t.false(isMatch(glob, "foo/qux/_"));
+  });
+
+  it("native_range", (t) => {
+    // Numeric
+
+    t.true(isMatch("{1..20}", "1"));
+    t.true(isMatch("{1..20}", "10"));
+    t.true(isMatch("{1..20}", "20"));
+
+    t.true(isMatch("{20..1}", "1"));
+    t.true(isMatch("{20..1}", "10"));
+    t.true(isMatch("{20..1}", "20"));
+
+    t.true(!isMatch("{1..20}", "0"));
+    t.true(!isMatch("{1..20}", "22"));
+
+    t.true(!isMatch("{20..1}", "0"));
+    t.true(!isMatch("{20..1}", "22"));
+
+    // Numeric padded
+
+    t.true(isMatch("{01..20}", "01"));
+    t.true(isMatch("{01..20}", "10"));
+    t.true(isMatch("{01..20}", "20"));
+
+    t.true(isMatch("{20..01}", "01"));
+    t.true(isMatch("{20..01}", "10"));
+    t.true(isMatch("{20..01}", "20"));
+
+    t.true(!isMatch("{01..20}", "00"));
+    t.true(!isMatch("{01..20}", "1"));
+    t.true(!isMatch("{01..20}", "22"));
+
+    t.true(!isMatch("{20..01}", "00"));
+    t.true(!isMatch("{20..01}", "1"));
+    t.true(!isMatch("{20..01}", "22"));
+
+    // Alphabetic
+
+    t.true(isMatch("{a..zz}", "a"));
+    t.true(isMatch("{a..zz}", "bb"));
+    t.true(isMatch("{a..zz}", "za"));
+
+    t.true(isMatch("{zz..a}", "a"));
+    t.true(isMatch("{zz..a}", "bb"));
+    t.true(isMatch("{zz..a}", "za"));
+
+    t.true(!isMatch("{a..zz}", "aaa"));
+    t.true(!isMatch("{a..zz}", "A"));
+
+    t.true(!isMatch("{zz..a}", "aaa"));
+    t.true(!isMatch("{zz..a}", "A"));
+
+    // Alphabetic uppercase
+
+    t.true(isMatch("{A..ZZ}", "A"));
+    t.true(isMatch("{A..ZZ}", "BB"));
+    t.true(isMatch("{A..ZZ}", "ZA"));
+
+    t.true(isMatch("{ZZ..A}", "A"));
+    t.true(isMatch("{ZZ..A}", "BB"));
+    t.true(isMatch("{ZZ..A}", "ZA"));
+
+    t.true(!isMatch("{A..ZZ}", "AAA"));
+    t.true(!isMatch("{A..ZZ}", "a"));
+
+    t.true(!isMatch("{ZZ..A}", "AAA"));
+    t.true(!isMatch("{ZZ..A}", "a"));
+  });
+
+  it("native_slashes_normalization", (t) => {
+    t.true(isMatch("foo/*.json", "foo\\bar.json"));
+    t.true(isMatch("foo/*.json", "foo/bar.json"));
+  });
+
+  it("native_trailing slash", (t) => {
+    t.true(isMatch("foo", "foo"));
+    t.true(isMatch("foo", "foo/"));
+
+    t.false(isMatch("foo/", "foo"));
+    t.true(isMatch("foo/", "foo/"));
+    t.true(isMatch("foo/", "foo//"));
+  });
+
+  // Tests adapted from "picomatch": https://github.com/micromatch/picomatch
+  // License: https://github.com/micromatch/picomatch/blob/master/LICENSE
+
+  it("multiple_patterns", (t) => {
+    t.true(isMatch([".", "foo"], "."));
+    t.true(isMatch(["a", "foo"], "a"));
+    t.true(isMatch(["*", "foo", "bar"], "ab"));
+    t.true(isMatch(["*b", "foo", "bar"], "ab"));
+    t.true(!isMatch(["./*", "foo", "bar"], "ab"));
+    t.true(isMatch(["a*", "foo", "bar"], "ab"));
+    t.true(isMatch(["ab", "foo"], "ab"));
+
+    t.true(!isMatch(["/a", "foo"], "/ab"));
+    t.true(!isMatch(["?/?", "foo", "bar"], "/ab"));
+    t.true(!isMatch(["a/*", "foo", "bar"], "/ab"));
+    t.true(!isMatch(["a/b", "foo"], "a/b/c"));
+    t.true(!isMatch(["*/*", "foo", "bar"], "ab"));
+    t.true(!isMatch(["/a", "foo", "bar"], "ab"));
+    t.true(!isMatch(["a", "foo"], "ab"));
+    t.true(!isMatch(["b", "foo"], "ab"));
+    t.true(!isMatch(["c", "foo", "bar"], "ab"));
+    t.true(!isMatch(["ab", "foo"], "abcd"));
+    t.true(!isMatch(["bc", "foo"], "abcd"));
+    t.true(!isMatch(["c", "foo"], "abcd"));
+    t.true(!isMatch(["cd", "foo"], "abcd"));
+    t.true(!isMatch(["d", "foo"], "abcd"));
+    t.true(!isMatch(["f", "foo", "bar"], "abcd"));
+    t.true(!isMatch(["/*", "foo", "bar"], "ef"));
+  });
+
+  it("file_extensions", (t) => {
+    t.true(isMatch("*.md", ".c.md"));
+    t.true(!isMatch(".c.", ".c.md"));
+    t.true(!isMatch(".md", ".c.md"));
+    t.true(isMatch("*.md", ".md"));
+    t.true(!isMatch(".m", ".md"));
+    t.true(!isMatch("*.md", "a/b/c.md"));
+    t.true(!isMatch(".md", "a/b/c.md"));
+    t.true(!isMatch("a/*.md", "a/b/c.md"));
+    t.true(!isMatch("*.md", "a/b/c/c.md"));
+    t.true(!isMatch("c.js", "a/b/c/c.md"));
+    t.true(isMatch(".*.md", ".c.md"));
+    t.true(isMatch(".md", ".md"));
+    t.true(isMatch("a/**/*.*", "a/b/c.js"));
+    t.true(isMatch("**/*.md", "a/b/c.md"));
+    t.true(isMatch("a/*/*.md", "a/b/c.md"));
+    t.true(isMatch("*.md", "c.md"));
+  });
+
+  it("dot_files", (t) => {
+    t.true(!isMatch(".*.md", "a/b/c/.xyz.md"));
+    t.true(isMatch("*.md", ".c.md"));
+    t.true(isMatch(".*", ".c.md"));
+    t.true(isMatch("**/*.md", "a/b/c/.xyz.md"));
+    t.true(isMatch("**/.*.md", "a/b/c/.xyz.md"));
+    t.true(isMatch("a/b/c/*.md", "a/b/c/.xyz.md"));
+    t.true(isMatch("a/b/c/.*.md", "a/b/c/.xyz.md"));
+  });
+
+  it("matching", (t) => {
+    t.true(isMatch("a+b/src/*.js", "a+b/src/glimini.js"));
+    t.true(isMatch("+b/src/*.js", "+b/src/glimini.js"));
+    t.true(isMatch("coffee+/src/*.js", "coffee+/src/glimini.js"));
+    t.true(isMatch("coffee+/src/*", "coffee+/src/glimini.js"));
+
+    t.true(isMatch(".", "."));
+    t.true(isMatch("/a", "/a"));
+    t.true(!isMatch("/a", "/ab"));
+    t.true(isMatch("a", "a"));
+    t.true(!isMatch("/a", "ab"));
+    t.true(!isMatch("a", "ab"));
+    t.true(isMatch("ab", "ab"));
+    t.true(!isMatch("cd", "abcd"));
+    t.true(!isMatch("bc", "abcd"));
+    t.true(!isMatch("ab", "abcd"));
+
+    t.true(isMatch("a.b", "a.b"));
+    t.true(isMatch("*.b", "a.b"));
+    t.true(isMatch("a.*", "a.b"));
+    t.true(isMatch("*.*", "a.b"));
+    t.true(isMatch("a*.c*", "a-b.c-d"));
+    t.true(isMatch("*b.*d", "a-b.c-d"));
+    t.true(isMatch("*.*", "a-b.c-d"));
+    t.true(isMatch("*.*-*", "a-b.c-d"));
+    t.true(isMatch("*-*.*-*", "a-b.c-d"));
+    t.true(isMatch("*.c-*", "a-b.c-d"));
+    t.true(isMatch("*.*-d", "a-b.c-d"));
+    t.true(isMatch("a-*.*-d", "a-b.c-d"));
+    t.true(isMatch("*-b.c-*", "a-b.c-d"));
+    t.true(isMatch("*-b*c-*", "a-b.c-d"));
+    t.true(!isMatch("*-bc-*", "a-b.c-d"));
+
+    t.true(!isMatch("./*/", "/ab"));
+    t.true(!isMatch("*", "/ef"));
+    t.true(!isMatch("./*/", "ab"));
+    t.true(!isMatch("/*", "ef"));
+    t.true(isMatch("/*", "/ab"));
+    t.true(isMatch("/*", "/cd"));
+    t.true(isMatch("*", "ab"));
+    t.true(!isMatch("./*", "ab"));
+    t.true(isMatch("ab", "ab"));
+    t.true(!isMatch("./*/", "ab/"));
+
+    t.true(!isMatch("*.js", "a/b/c/z.js"));
+    t.true(!isMatch("*.js", "a/b/z.js"));
+    t.true(!isMatch("*.js", "a/z.js"));
+    t.true(isMatch("*.js", "z.js"));
+
+    t.true(isMatch("z*.js", "z.js"));
+    t.true(isMatch("a/z*.js", "a/z.js"));
+    t.true(isMatch("*/z*.js", "a/z.js"));
+
+    t.true(isMatch("**/*.js", "a/b/c/z.js"));
+    t.true(isMatch("**/*.js", "a/b/z.js"));
+    t.true(isMatch("**/*.js", "a/z.js"));
+    t.true(isMatch("a/b/**/*.js", "a/b/c/d/e/z.js"));
+    t.true(isMatch("a/b/**/*.js", "a/b/c/d/z.js"));
+    t.true(isMatch("a/b/c/**/*.js", "a/b/c/z.js"));
+    t.true(isMatch("a/b/c**/*.js", "a/b/c/z.js"));
+    t.true(isMatch("a/b/**/*.js", "a/b/c/z.js"));
+    t.true(isMatch("a/b/**/*.js", "a/b/z.js"));
+
+    t.true(!isMatch("a/b/**/*.js", "a/z.js"));
+    t.true(!isMatch("a/b/**/*.js", "z.js"));
+
+    t.true(isMatch("z*", "z.js"));
+    t.true(isMatch("**/z*", "z.js"));
+    t.true(isMatch("**/z*.js", "z.js"));
+    t.true(isMatch("**/*.js", "z.js"));
+    t.true(isMatch("**/foo", "foo"));
+
+    t.true(!isMatch("z*.js", "zzjs"));
+    t.true(!isMatch("*z.js", "zzjs"));
+
+    t.true(!isMatch("a/b/**/f", "a/b/c/d/"));
+    t.true(isMatch("a/**", "a"));
+    t.true(isMatch("**", "a"));
+    t.true(isMatch("**", "a/"));
+    t.true(isMatch("a/b-*/**/z.js", "a/b-c/d/e/z.js"));
+    t.true(isMatch("a/b-*/**/z.js", "a/b-c/z.js"));
+    t.true(isMatch("**", "a/b/c/d"));
+    t.true(isMatch("**", "a/b/c/d/"));
+    t.true(isMatch("**/**", "a/b/c/d/"));
+    t.true(isMatch("**/b/**", "a/b/c/d/"));
+    t.true(isMatch("a/b/**", "a/b/c/d/"));
+    t.true(isMatch("a/b/**/", "a/b/c/d/"));
+    t.true(isMatch("a/b/**/c/**/", "a/b/c/d/"));
+    t.true(isMatch("a/b/**/c/**/d/", "a/b/c/d/"));
+    t.true(isMatch("a/b/**/**/*.*", "a/b/c/d/e.f"));
+    t.true(isMatch("a/b/**/*.*", "a/b/c/d/e.f"));
+    t.true(isMatch("a/b/**/c/**/d/*.*", "a/b/c/d/e.f"));
+    t.true(isMatch("a/b/**/d/**/*.*", "a/b/c/d/e.f"));
+    t.true(isMatch("a/b/**/d/**/*.*", "a/b/c/d/g/e.f"));
+    t.true(isMatch("a/b/**/d/**/*.*", "a/b/c/d/g/g/e.f"));
+
+    t.true(!isMatch("*/foo", "bar/baz/foo"));
+    t.true(!isMatch("**/bar/*", "deep/foo/bar"));
+    t.true(!isMatch("*/bar/**", "deep/foo/bar/baz/x"));
+    t.true(!isMatch("foo?bar", "foo/bar"));
+    t.true(!isMatch("**/bar*", "foo/bar/baz"));
+    t.true(!isMatch("**/bar**", "foo/bar/baz"));
+    t.true(!isMatch("foo**bar", "foo/baz/bar"));
+    t.true(!isMatch("foo*bar", "foo/baz/bar"));
+    t.true(!isMatch("**/bar/*/", "deep/foo/bar/baz"));
+    t.true(isMatch("**/bar/*", "deep/foo/bar/baz/"));
+    t.true(isMatch("**/bar/*", "deep/foo/bar/baz"));
+    t.true(isMatch("foo/**", "foo"));
+    t.true(isMatch("**/bar/*{,/}", "deep/foo/bar/baz/"));
+    t.true(isMatch("a/**/j/**/z/*.md", "a/b/j/c/z/x.md"));
+    t.true(isMatch("a/**/j/**/z/*.md", "a/j/z/x.md"));
+    t.true(isMatch("**/foo", "bar/baz/foo"));
+    t.true(isMatch("**/bar/**", "deep/foo/bar/"));
+    t.true(isMatch("**/bar/*", "deep/foo/bar/baz"));
+    t.true(isMatch("**/bar/*/", "deep/foo/bar/baz/"));
+    t.true(isMatch("**/bar/**", "deep/foo/bar/baz/"));
+    t.true(isMatch("**/bar/*/*", "deep/foo/bar/baz/x"));
+    t.true(isMatch("foo/**/**/bar", "foo/b/a/z/bar"));
+    t.true(isMatch("foo/**/bar", "foo/b/a/z/bar"));
+    t.true(isMatch("foo/**/**/bar", "foo/bar"));
+    t.true(isMatch("foo/**/bar", "foo/bar"));
+    t.true(isMatch("foo[/]bar", "foo/bar"));
+    t.true(isMatch("*/bar/**", "foo/bar/baz/x"));
+    t.true(isMatch("foo/**/**/bar", "foo/baz/bar"));
+    t.true(isMatch("foo/**/bar", "foo/baz/bar"));
+    t.true(isMatch("foo**bar", "foobazbar"));
+    t.true(isMatch("**/foo", "XXX/foo"));
+
+    t.true(isMatch("foo//baz.md", "foo//baz.md"));
+    t.true(isMatch("foo//*baz.md", "foo//baz.md"));
+    t.true(isMatch("foo{/,//}baz.md", "foo//baz.md"));
+    t.true(isMatch("foo{/,//}baz.md", "foo/baz.md"));
+    t.true(!isMatch("foo/+baz.md", "foo//baz.md"));
+    t.true(!isMatch("foo//+baz.md", "foo//baz.md"));
+    t.true(!isMatch("foo/baz.md", "foo//baz.md"));
+    t.true(!isMatch("foo//baz.md", "foo/baz.md"));
+
+    t.true(!isMatch("aaa?bbb", "aaa/bbb"));
+
+    t.true(isMatch("*.md", ".c.md"));
+    t.true(!isMatch("*.md", "a/.c.md"));
+    t.true(isMatch("a/.c.md", "a/.c.md"));
+    t.true(!isMatch("*.md", ".a"));
+    t.true(!isMatch("*.md", ".verb.txt"));
+    t.true(isMatch("a/b/c/.*.md", "a/b/c/.xyz.md"));
+    t.true(isMatch(".md", ".md"));
+    t.true(!isMatch(".md", ".txt"));
+    t.true(isMatch(".md", ".md"));
+    t.true(isMatch(".a", ".a"));
+    t.true(isMatch(".b*", ".b"));
+    t.true(isMatch(".a*", ".ab"));
+    t.true(isMatch(".*", ".ab"));
+    t.true(isMatch("*.*", ".ab"));
+    t.true(!isMatch("a/b/c/*.md", ".md"));
+    t.true(!isMatch("a/b/c/*.md", ".a.md"));
+    t.true(isMatch("a/b/c/*.md", "a/b/c/d.a.md"));
+    t.true(!isMatch("a/b/c/*.md", "a/b/d/.md"));
+
+    t.true(isMatch("*.md", ".c.md"));
+    t.true(isMatch(".*", ".c.md"));
+    t.true(isMatch("a/b/c/*.md", "a/b/c/.xyz.md"));
+    t.true(isMatch("a/b/c/.*.md", "a/b/c/.xyz.md"));
+  });
+
+  it("brackets", (t) => {
+    t.true(isMatch("foo[/]bar", "foo/bar"));
+    t.true(isMatch("foo[/]bar[/]", "foo/bar/"));
+    t.true(isMatch("foo[/]bar[/]baz", "foo/bar/baz"));
+  });
+
+  it("ranges", (t) => {
+    t.true(isMatch("a/{a..c}", "a/c"));
+    t.true(!isMatch("a/{a..c}", "a/z"));
+    t.true(isMatch("a/{1..100}", "a/99"));
+    t.true(!isMatch("a/{1..100}", "a/101"));
+    t.true(isMatch("a/{01..10}", "a/02"));
+    t.true(!isMatch("a/{01..10}", "a/2"));
+  });
+
+  it("exploits", (t) => {
+    t.true(!isMatch(`${"\\".repeat(65500)}A`, "\\A")); // This matches in picomatch, but why though?
+    t.true(isMatch(`!${"\\".repeat(65500)}A`, "A"));
+    t.true(isMatch(`!(${"\\".repeat(65500)}A)`, "A"));
+    t.true(!isMatch(`[!(${"\\".repeat(65500)}A`, "A"));
+  });
+
+  it("wildmat", (t) => {
+    t.true(!isMatch("*f", "foo"));
+    t.true(!isMatch("??", "foo"));
+    t.true(!isMatch("bar", "foo"));
+    t.true(!isMatch("foo\\*bar", "foobar"));
+    t.true(isMatch("\\??\\?b", "?a?b"));
+    t.true(isMatch("*ab", "aaaaaaabababab"));
+    t.true(isMatch("*", "foo"));
+    t.true(isMatch("*foo*", "foo"));
+    t.true(isMatch("???", "foo"));
+    t.true(isMatch("f*", "foo"));
+    t.true(isMatch("foo", "foo"));
+    t.true(isMatch("*ob*a*r*", "foobar"));
+
+    t.true(
+      !isMatch(
+        "-*-*-*-*-*-*-12-*-*-*-m-*-*-*",
+        "-adobe-courier-bold-o-normal--12-120-75-75-/-70-iso8859-1",
+      ),
+    );
+    t.true(
+      !isMatch(
+        "-*-*-*-*-*-*-12-*-*-*-m-*-*-*",
+        "-adobe-courier-bold-o-normal--12-120-75-75-X-70-iso8859-1",
+      ),
+    );
+    t.true(!isMatch("*X*i", "ab/cXd/efXg/hi"));
+    t.true(!isMatch("*Xg*i", "ab/cXd/efXg/hi"));
+    t.true(!isMatch("**/*a*b*g*n*t", "abcd/abcdefg/abcdefghijk/abcdefghijklmnop.txtz"));
+    t.true(!isMatch("*/*/*", "foo"));
+    t.true(!isMatch("fo", "foo"));
+    t.true(!isMatch("*/*/*", "foo/bar"));
+    t.true(!isMatch("foo?bar", "foo/bar"));
+    t.true(!isMatch("*/*/*", "foo/bb/aa/rr"));
+    t.true(!isMatch("foo*", "foo/bba/arr"));
+    t.true(!isMatch("foo**", "foo/bba/arr"));
+    t.true(!isMatch("foo/*", "foo/bba/arr"));
+    t.true(!isMatch("foo/**arr", "foo/bba/arr"));
+    t.true(!isMatch("foo/**z", "foo/bba/arr"));
+    t.true(!isMatch("foo/*arr", "foo/bba/arr"));
+    t.true(!isMatch("foo/*z", "foo/bba/arr"));
+    t.true(
+      !isMatch(
+        "XXX/*/*/*/*/*/*/12/*/*/*/m/*/*/*",
+        "XXX/adobe/courier/bold/o/normal//12/120/75/75/X/70/iso8859/1",
+      ),
+    );
+    t.true(
+      isMatch(
+        "-*-*-*-*-*-*-12-*-*-*-m-*-*-*",
+        "-adobe-courier-bold-o-normal--12-120-75-75-m-70-iso8859-1",
+      ),
+    );
+    t.true(isMatch("**/*X*/**/*i", "ab/cXd/efXg/hi"));
+    t.true(isMatch("*/*X*/*/*i", "ab/cXd/efXg/hi"));
+    t.true(isMatch("**/*a*b*g*n*t", "abcd/abcdefg/abcdefghijk/abcdefghijklmnop.txt"));
+    t.true(isMatch("*X*i", "abcXdefXghi"));
+    t.true(isMatch("foo", "foo"));
+    t.true(isMatch("foo/*", "foo/bar"));
+    t.true(isMatch("foo/bar", "foo/bar"));
+    t.true(isMatch("foo[/]bar", "foo/bar"));
+    t.true(isMatch("**/**/**", "foo/bb/aa/rr"));
+    t.true(isMatch("*/*/*", "foo/bba/arr"));
+    t.true(isMatch("foo/**", "foo/bba/arr"));
+  });
+
+  it.skip("posix_classes", (t) => {
+    t.true(isMatch("[[:xdigit:]]", "e"));
+
+    t.true(isMatch("[[:alpha:]123]", "a"));
+    t.true(isMatch("[[:alpha:]123]", "1"));
+    t.true(!isMatch("[[:alpha:]123]", "5"));
+    t.true(isMatch("[[:alpha:]123]", "A"));
+
+    t.true(isMatch("[[:alpha:]]", "A"));
+    t.true(!isMatch("[[:alpha:]]", "9"));
+    t.true(isMatch("[[:alpha:]]", "b"));
+
+    t.true(!isMatch("[![:alpha:]]", "A"));
+    t.true(isMatch("[![:alpha:]]", "9"));
+    t.true(!isMatch("[![:alpha:]]", "b"));
+
+    t.true(!isMatch("[^[:alpha:]]", "A"));
+    t.true(isMatch("[^[:alpha:]]", "9"));
+    t.true(!isMatch("[^[:alpha:]]", "b"));
+
+    t.true(!isMatch("[[:digit:]]", "A"));
+    t.true(isMatch("[[:digit:]]", "9"));
+    t.true(!isMatch("[[:digit:]]", "b"));
+
+    t.true(isMatch("[^[:digit:]]", "A"));
+    t.true(!isMatch("[^[:digit:]]", "9"));
+    t.true(isMatch("[^[:digit:]]", "b"));
+
+    t.true(isMatch("[![:digit:]]", "A"));
+    t.true(!isMatch("[![:digit:]]", "9"));
+    t.true(isMatch("[![:digit:]]", "b"));
+
+    t.true(isMatch("[[:lower:]]", "a"));
+    t.true(!isMatch("[[:lower:]]", "A"));
+    t.true(!isMatch("[[:lower:]]", "9"));
+
+    t.true(isMatch("[:alpha:]", "a"));
+    t.true(isMatch("[:alpha:]", "l"));
+    t.true(isMatch("[:alpha:]", "p"));
+    t.true(isMatch("[:alpha:]", "h"));
+    t.true(isMatch("[:alpha:]", ":"));
+    t.true(!isMatch("[:alpha:]", "b"));
+
+    t.true(isMatch("[[:lower:][:digit:]]", "9"));
+    t.true(isMatch("[[:lower:][:digit:]]", "a"));
+    t.true(!isMatch("[[:lower:][:digit:]]", "A"));
+    t.true(!isMatch("[[:lower:][:digit:]]", "aa"));
+    t.true(!isMatch("[[:lower:][:digit:]]", "99"));
+    t.true(!isMatch("[[:lower:][:digit:]]", "a9"));
+    t.true(!isMatch("[[:lower:][:digit:]]", "9a"));
+    t.true(!isMatch("[[:lower:][:digit:]]", "aA"));
+    t.true(!isMatch("[[:lower:][:digit:]]", "9A"));
+    t.true(isMatch("[[:lower:][:digit:]]+", "aa"));
+    t.true(isMatch("[[:lower:][:digit:]]+", "99"));
+    t.true(isMatch("[[:lower:][:digit:]]+", "a9"));
+    t.true(isMatch("[[:lower:][:digit:]]+", "9a"));
+    t.true(!isMatch("[[:lower:][:digit:]]+", "aA"));
+    t.true(!isMatch("[[:lower:][:digit:]]+", "9A"));
+    t.true(isMatch("[[:lower:][:digit:]]*", "a"));
+    t.true(!isMatch("[[:lower:][:digit:]]*", "A"));
+    t.true(!isMatch("[[:lower:][:digit:]]*", "AA"));
+    t.true(isMatch("[[:lower:][:digit:]]*", "aa"));
+    t.true(isMatch("[[:lower:][:digit:]]*", "aaa"));
+    t.true(isMatch("[[:lower:][:digit:]]*", "999"));
+
+    t.true(!isMatch("a[[:word:]]+c", "a c"));
+    t.true(!isMatch("a[[:word:]]+c", "a.c"));
+    t.true(!isMatch("a[[:word:]]+c", "a.xy.zc"));
+    t.true(!isMatch("a[[:word:]]+c", "a.zc"));
+    t.true(!isMatch("a[[:word:]]+c", "abq"));
+    t.true(!isMatch("a[[:word:]]+c", "axy zc"));
+    t.true(!isMatch("a[[:word:]]+c", "axy"));
+    t.true(!isMatch("a[[:word:]]+c", "axy.zc"));
+    t.true(isMatch("a[[:word:]]+c", "a123c"));
+    t.true(isMatch("a[[:word:]]+c", "a1c"));
+    t.true(isMatch("a[[:word:]]+c", "abbbbc"));
+    t.true(isMatch("a[[:word:]]+c", "abbbc"));
+    t.true(isMatch("a[[:word:]]+c", "abbc"));
+    t.true(isMatch("a[[:word:]]+c", "abc"));
+
+    t.true(!isMatch("a[[:word:]]+", "a c"));
+    t.true(!isMatch("a[[:word:]]+", "a.c"));
+    t.true(!isMatch("a[[:word:]]+", "a.xy.zc"));
+    t.true(!isMatch("a[[:word:]]+", "a.zc"));
+    t.true(!isMatch("a[[:word:]]+", "axy zc"));
+    t.true(!isMatch("a[[:word:]]+", "axy.zc"));
+    t.true(isMatch("a[[:word:]]+", "a123c"));
+    t.true(isMatch("a[[:word:]]+", "a1c"));
+    t.true(isMatch("a[[:word:]]+", "abbbbc"));
+    t.true(isMatch("a[[:word:]]+", "abbbc"));
+    t.true(isMatch("a[[:word:]]+", "abbc"));
+    t.true(isMatch("a[[:word:]]+", "abc"));
+    t.true(isMatch("a[[:word:]]+", "abq"));
+    t.true(isMatch("a[[:word:]]+", "axy"));
+    t.true(isMatch("a[[:word:]]+", "axyzc"));
+    t.true(isMatch("a[[:word:]]+", "axyzc"));
+
+    t.true(isMatch("[[:lower:]]", "a"));
+    t.true(isMatch("[[:upper:]]", "A"));
+    t.true(isMatch("[[:digit:][:upper:][:space:]]", "A"));
+    t.true(isMatch("[[:digit:][:upper:][:space:]]", "1"));
+    t.true(isMatch("[[:digit:][:upper:][:space:]]", " "));
+    t.true(isMatch("[[:xdigit:]]", "5"));
+    t.true(isMatch("[[:xdigit:]]", "f"));
+    t.true(isMatch("[[:xdigit:]]", "D"));
+    t.true(
+      isMatch(
+        "[[:alnum:][:alpha:][:blank:][:cntrl:][:digit:][:graph:][:lower:][:print:][:punct:][:space:][:upper:][:xdigit:]]",
+        "_",
+      ),
+    );
+    t.true(
+      isMatch(
+        "[[:alnum:][:alpha:][:blank:][:cntrl:][:digit:][:graph:][:lower:][:print:][:punct:][:space:][:upper:][:xdigit:]]",
+        "_",
+      ),
+    );
+    t.true(
+      isMatch(
+        "[^[:alnum:][:alpha:][:blank:][:cntrl:][:digit:][:lower:][:space:][:upper:][:xdigit:]]",
+        ".",
+      ),
+    );
+    t.true(isMatch("[a-c[:digit:]x-z]", "5"));
+    t.true(isMatch("[a-c[:digit:]x-z]", "b"));
+    t.true(isMatch("[a-c[:digit:]x-z]", "y"));
+
+    t.true(!isMatch("[[:lower:]]", "A"));
+    t.true(isMatch("[![:lower:]]", "A"));
+    t.true(!isMatch("[[:upper:]]", "a"));
+    t.true(!isMatch("[[:digit:][:upper:][:space:]]", "a"));
+    t.true(!isMatch("[[:digit:][:upper:][:space:]]", "."));
+    t.true(
+      !isMatch(
+        "[[:alnum:][:alpha:][:blank:][:cntrl:][:digit:][:lower:][:space:][:upper:][:xdigit:]]",
+        ".",
+      ),
+    );
+    t.true(!isMatch("[a-c[:digit:]x-z]", "q"));
+
+    t.true(isMatch("a [b]", "a [b]"));
+    t.true(isMatch("a [b]", "a b"));
+
+    t.true(isMatch("a [b] c", "a [b] c"));
+    t.true(isMatch("a [b] c", "a b c"));
+
+    t.true(isMatch("a \\[b\\]", "a [b]"));
+    t.true(!isMatch("a \\[b\\]", "a b"));
+
+    t.true(isMatch("a ([b])", "a [b]"));
+    t.true(isMatch("a ([b])", "a b"));
+
+    t.true(isMatch("a (\\[b\\]|[b])", "a b"));
+    t.true(isMatch("a (\\[b\\]|[b])", "a [b]"));
+
+    t.true(isMatch("[[:xdigit:]]", "e"));
+    t.true(isMatch("[[:xdigit:]]", "1"));
+    t.true(isMatch("[[:alpha:]123]", "a"));
+    t.true(isMatch("[[:alpha:]123]", "1"));
+
+    t.true(isMatch("[![:alpha:]]", "9"));
+    t.true(isMatch("[^[:alpha:]]", "9"));
+
+    t.true(isMatch("[[:word:]]", "A"));
+    t.true(isMatch("[[:word:]]", "B"));
+    t.true(isMatch("[[:word:]]", "a"));
+    t.true(isMatch("[[:word:]]", "b"));
+
+    t.true(isMatch("[[:word:]]", "1"));
+    t.true(isMatch("[[:word:]]", "2"));
+
+    t.true(isMatch("[[:digit:]]", "1"));
+    t.true(isMatch("[[:digit:]]", "2"));
+
+    t.true(!isMatch("[[:digit:]]", "a"));
+    t.true(!isMatch("[[:digit:]]", "A"));
+
+    t.true(isMatch("[[:upper:]]", "A"));
+    t.true(isMatch("[[:upper:]]", "B"));
+
+    t.true(!isMatch("[[:upper:]]", "a"));
+    t.true(!isMatch("[[:upper:]]", "b"));
+
+    t.true(!isMatch("[[:upper:]]", "1"));
+    t.true(!isMatch("[[:upper:]]", "2"));
+
+    t.true(isMatch("[[:lower:]]", "a"));
+    t.true(isMatch("[[:lower:]]", "b"));
+
+    t.true(!isMatch("[[:lower:]]", "A"));
+    t.true(!isMatch("[[:lower:]]", "B"));
+
+    t.true(isMatch("[[:lower:]][[:upper:]]", "aA"));
+    t.true(!isMatch("[[:lower:]][[:upper:]]", "AA"));
+    t.true(!isMatch("[[:lower:]][[:upper:]]", "Aa"));
+
+    t.true(isMatch("[[:xdigit:]]*", "ababab"));
+    t.true(isMatch("[[:xdigit:]]*", "020202"));
+    t.true(isMatch("[[:xdigit:]]*", "900"));
+
+    t.true(isMatch("[[:punct:]]", "!"));
+    t.true(isMatch("[[:punct:]]", "?"));
+    t.true(isMatch("[[:punct:]]", "#"));
+    t.true(isMatch("[[:punct:]]", "&"));
+    t.true(isMatch("[[:punct:]]", "@"));
+    t.true(isMatch("[[:punct:]]", "+"));
+    t.true(isMatch("[[:punct:]]", "*"));
+    t.true(isMatch("[[:punct:]]", ":"));
+    t.true(isMatch("[[:punct:]]", "="));
+    t.true(isMatch("[[:punct:]]", "|"));
+    t.true(isMatch("[[:punct:]]*", "|++"));
+
+    t.true(!isMatch("[[:punct:]]", "?*+"));
+
+    t.true(isMatch("[[:punct:]]*", "?*+"));
+    t.true(isMatch("foo[[:punct:]]*", "foo"));
+    t.true(isMatch("foo[[:punct:]]*", "foo?*+"));
+
+    t.true(isMatch("[:al:]", "a"));
+    t.true(isMatch("[[:al:]", "a"));
+    t.true(isMatch("[abc[:punct:][0-9]", "!"));
+
+    t.true(isMatch("[_[:alpha:]]*", "PATH"));
+
+    t.true(isMatch("[_[:alpha:]][_[:alnum:]]*", "PATH"));
+
+    t.true(isMatch("[[:alpha:]][[:digit:]][[:upper:]]", "a1B"));
+    t.true(!isMatch("[[:alpha:]][[:digit:]][[:upper:]]", "a1b"));
+    t.true(isMatch("[[:digit:][:punct:][:space:]]", "."));
+    t.true(!isMatch("[[:digit:][:punct:][:space:]]", "a"));
+    t.true(isMatch("[[:digit:][:punct:][:space:]]", "!"));
+    t.true(!isMatch("[[:digit:]][[:punct:]][[:space:]]", "!"));
+    t.true(isMatch("[[:digit:]][[:punct:]][[:space:]]", "1! "));
+    t.true(!isMatch("[[:digit:]][[:punct:]][[:space:]]", "1!  "));
+
+    t.true(isMatch("[[:digit:]]", "9"));
+    t.true(!isMatch("[[:digit:]]", "X"));
+    t.true(isMatch("[[:lower:]][[:upper:]]", "aB"));
+    t.true(isMatch("[[:alpha:][:digit:]]", "a"));
+    t.true(isMatch("[[:alpha:][:digit:]]", "3"));
+    t.true(!isMatch("[[:alpha:][:digit:]]", "aa"));
+    t.true(!isMatch("[[:alpha:][:digit:]]", "a3"));
+    t.true(!isMatch("[[:alpha:]\\]", "a"));
+    t.true(!isMatch("[[:alpha:]\\]", "b"));
+
+    t.true(isMatch("[[:blank:]]", "\t"));
+    t.true(isMatch("[[:space:]]", "\t"));
+    t.true(isMatch("[[:space:]]", " "));
+
+    t.true(!isMatch("[[:ascii:]]", "\\377"));
+    t.true(!isMatch("[1[:alpha:]123]", "9"));
+
+    t.true(!isMatch("[[:punct:]]", " "));
+
+    t.true(isMatch("[[:graph:]]", "A"));
+    t.true(!isMatch("[[:graph:]]", "\\b"));
+    t.true(!isMatch("[[:graph:]]", "\\n"));
+    t.true(!isMatch("[[:graph:]]", "\\s"));
+  });
+
+  it.skip("extglobs", (t) => {
+    t.true(isMatch("c!(.)z", "cbz"));
+    t.true(!isMatch("c!(*)z", "cbz"));
+    t.true(isMatch("c!(b*)z", "cccz"));
+    t.true(isMatch("c!(+)z", "cbz"));
+    t.true(!isMatch("c!(?)z", "cbz")); // This matches in picomatch, but why though?
+    t.true(isMatch("c!(@)z", "cbz"));
+
+    t.true(!isMatch("c!(?:foo)?z", "c/z"));
+    t.true(isMatch("c!(?:foo)?z", "c!fooz"));
+    t.true(isMatch("c!(?:foo)?z", "c!z"));
+
+    // t.true ( !isMatch ( '!(abc)', 'abc' ) );
+    // t.true ( !isMatch ( '!(a)', 'a' ) );
+    // t.true ( isMatch ( '!(a)', 'aa' ) );
+    // t.true ( isMatch ( '!(a)', 'b' ) );
+
+    t.true(isMatch("a!(b)c", "aac"));
+    t.true(!isMatch("a!(b)c", "abc"));
+    t.true(isMatch("a!(b)c", "acc"));
+    t.true(isMatch("a!(z)", "abz"));
+    t.true(!isMatch("a!(z)", "az"));
+
+    t.true(!isMatch("a!(.)", "a."));
+    t.true(!isMatch("!(.)a", ".a"));
+    t.true(!isMatch("a!(.)c", "a.c"));
+    t.true(isMatch("a!(.)c", "abc"));
+
+    t.true(!isMatch("/!(*.d).ts", "/file.d.ts"));
+    t.true(isMatch("/!(*.d).ts", "/file.ts"));
+    t.true(isMatch("/!(*.d).ts", "/file.something.ts"));
+    // t.true ( isMatch ( '/!(*.d).ts', '/file.d.something.ts' ) );
+    // t.true ( isMatch ( '/!(*.d).ts', '/file.dhello.ts' ) );
+
+    // t.true ( !isMatch ( '**/!(*.d).ts', '/file.d.ts' ) );
+    // t.true ( isMatch ( '**/!(*.d).ts', '/file.ts' ) );
+    // t.true ( isMatch ( '**/!(*.d).ts', '/file.something.ts' ) );
+    // t.true ( isMatch ( '**/!(*.d).ts', '/file.d.something.ts' ) );
+    // t.true ( isMatch ( '**/!(*.d).ts', '/file.dhello.ts' ) );
+
+    // t.true ( !isMatch ( '/!(*.d).{ts,tsx}', '/file.d.ts' ) );
+    // t.true ( isMatch ( '/!(*.d).{ts,tsx}', '/file.ts' ) );
+    // t.true ( isMatch ( '/!(*.d).{ts,tsx}', '/file.something.ts' ) );
+    // t.true ( isMatch ( '/!(*.d).{ts,tsx}', '/file.d.something.ts' ) );
+    // t.true ( isMatch ( '/!(*.d).{ts,tsx}', '/file.dhello.ts' ) );
+
+    // t.true ( !isMatch ( '/!(*.d).@(ts)', '/file.d.ts' ) );
+    // t.true ( isMatch ( '/!(*.d).@(ts)', '/file.ts' ) );
+    // t.true ( isMatch ( '/!(*.d).@(ts)', '/file.something.ts' ) );
+    // t.true ( isMatch ( '/!(*.d).@(ts)', '/file.d.something.ts' ) );
+    // t.true ( isMatch ( '/!(*.d).@(ts)', '/file.dhello.ts' ) );
+
+    t.true(!isMatch("foo/!(abc)", "foo/abc"));
+    t.true(isMatch("foo/!(abc)", "foo/bar"));
+
+    t.true(!isMatch("a/!(z)", "a/z"));
+    t.true(isMatch("a/!(z)", "a/b"));
+
+    t.true(!isMatch("c/!(z)/v", "c/z/v"));
+    t.true(isMatch("c/!(z)/v", "c/a/v"));
+
+    t.true(isMatch("!(b/a)", "a/a"));
+    t.true(!isMatch("!(b/a)", "b/a"));
+
+    // t.true ( !isMatch ( '!(!(foo))*', 'foo/bar' ) );
+    t.true(isMatch("!(b/a)", "a/a"));
+    t.true(!isMatch("!(b/a)", "b/a"));
+
+    // t.true ( isMatch ( '(!(b/a))', 'a/a' ) );
+    // t.true ( isMatch ( '!((b/a))', 'a/a' ) );
+    // t.true ( !isMatch ( '!((b/a))', 'b/a' ) );
+
+    t.true(!isMatch("(!(?:b/a))", "a/a"));
+    t.true(!isMatch("!((?:b/a))", "b/a"));
+
+    // t.true ( isMatch ( '!(b/(a))', 'a/a' ) );
+    // t.true ( !isMatch ( '!(b/(a))', 'b/a' ) );
+
+    t.true(isMatch("!(b/a)", "a/a"));
+    t.true(!isMatch("!(b/a)", "b/a"));
+
+    // t.true ( !isMatch ( 'c!(z)', 'c/z' ) );
+    // t.true ( !isMatch ( 'c!(z)z', 'c/z' ) );
+    // t.true ( !isMatch ( 'c!(.)z', 'c/z' ) );
+    // t.true ( !isMatch ( 'c!(*)z', 'c/z' ) );
+    // t.true ( !isMatch ( 'c!(+)z', 'c/z' ) );
+    // t.true ( !isMatch ( 'c!(?)z', 'c/z' ) );
+    // t.true ( !isMatch ( 'c!(@)z', 'c/z' ) );
+
+    // t.true ( !isMatch ( 'a!(z)', 'c/z' ) );
+    // t.true ( !isMatch ( 'c!(.)z', 'c/z' ) );
+    // t.true ( !isMatch ( 'c!(/)z', 'c/z' ) );
+    // t.true ( !isMatch ( 'c!(/z)z', 'c/z' ) );
+    // t.true ( !isMatch ( 'c!(/z)z', 'c/b' ) );
+    // t.true ( isMatch ( 'c!(/z)z', 'c/b/z' ) );
+
+    // t.true ( isMatch ( '!!(abc)', 'abc' ) );
+    // t.true ( !isMatch ( '!!!(abc)', 'abc' ) );
+    // t.true ( isMatch ( '!!!!(abc)', 'abc' ) );
+    // t.true ( !isMatch ( '!!!!!(abc)', 'abc' ) );
+    // t.true ( isMatch ( '!!!!!!(abc)', 'abc' ) );
+    // t.true ( !isMatch ( '!!!!!!!(abc)', 'abc' ) );
+    // t.true ( isMatch ( '!!!!!!!!(abc)', 'abc' ) );
+
+    // t.true ( isMatch ( '!(!(abc))', 'abc' ) );
+    // t.true ( !isMatch ( '!(!(!(abc)))', 'abc' ) );
+    // t.true ( isMatch ( '!(!(!(!(abc))))', 'abc' ) );
+    // t.true ( !isMatch ( '!(!(!(!(!(abc)))))', 'abc' ) );
+    // t.true ( isMatch ( '!(!(!(!(!(!(abc))))))', 'abc' ) );
+    // t.true ( !isMatch ( '!(!(!(!(!(!(!(abc)))))))', 'abc' ) );
+    // t.true ( isMatch ( '!(!(!(!(!(!(!(!(abc))))))))', 'abc' ) );
+
+    // t.true ( isMatch ( 'foo/!(!(abc))', 'foo/abc' ) );
+    // t.true ( !isMatch ( 'foo/!(!(!(abc)))', 'foo/abc' ) );
+    // t.true ( isMatch ( 'foo/!(!(!(!(abc))))', 'foo/abc' ) );
+    // t.true ( !isMatch ( 'foo/!(!(!(!(!(abc)))))', 'foo/abc' ) );
+    // t.true ( isMatch ( 'foo/!(!(!(!(!(!(abc))))))', 'foo/abc' ) );
+    // t.true ( !isMatch ( 'foo/!(!(!(!(!(!(!(abc)))))))', 'foo/abc' ) );
+    // t.true ( isMatch ( 'foo/!(!(!(!(!(!(!(!(abc))))))))', 'foo/abc' ) );
+
+    t.true(!isMatch("!(moo).!(cow)", "moo.cow"));
+    t.true(!isMatch("!(moo).!(cow)", "foo.cow"));
+    t.true(!isMatch("!(moo).!(cow)", "moo.bar"));
+    t.true(isMatch("!(moo).!(cow)", "foo.bar"));
+
+    // t.true ( !isMatch ( '@(!(a) )*', 'a   ' ) );
+    // t.true ( !isMatch ( '@(!(a) )*', 'a   b' ) );
+    // t.true ( !isMatch ( '@(!(a) )*', 'a  b' ) );
+    // t.true ( !isMatch ( '@(!(a) )*', 'a  ' ) );
+    // t.true ( !isMatch ( '@(!(a) )*', 'a ' ) );
+    // t.true ( !isMatch ( '@(!(a) )*', 'a' ) );
+    // t.true ( !isMatch ( '@(!(a) )*', 'aa' ) );
+    // t.true ( !isMatch ( '@(!(a) )*', 'b' ) );
+    // t.true ( !isMatch ( '@(!(a) )*', 'bb' ) );
+    // t.true ( isMatch ( '@(!(a) )*', ' a ' ) );
+    // t.true ( isMatch ( '@(!(a) )*', 'b  ' ) );
+    // t.true ( isMatch ( '@(!(a) )*', 'b ' ) );
+
+    t.true(!isMatch("a*!(z)", "c/z"));
+    t.true(isMatch("a*!(z)", "abz"));
+    t.true(isMatch("a*!(z)", "az"));
+
+    t.true(!isMatch("!(a*)", "a"));
+    t.true(!isMatch("!(a*)", "aa"));
+    t.true(!isMatch("!(a*)", "ab"));
+    t.true(isMatch("!(a*)", "b"));
+
+    t.true(!isMatch("!(*a*)", "a"));
+    t.true(!isMatch("!(*a*)", "aa"));
+    t.true(!isMatch("!(*a*)", "ab"));
+    t.true(!isMatch("!(*a*)", "ac"));
+    t.true(isMatch("!(*a*)", "b"));
+
+    // t.true ( !isMatch ( '!(*a)', 'a' ) );
+    // t.true ( !isMatch ( '!(*a)', 'aa' ) );
+    // t.true ( !isMatch ( '!(*a)', 'bba' ) );
+    // t.true ( isMatch ( '!(*a)', 'ab' ) );
+    // t.true ( isMatch ( '!(*a)', 'ac' ) );
+    // t.true ( isMatch ( '!(*a)', 'b' ) );
+
+    t.true(!isMatch("!(*a)*", "a"));
+    t.true(!isMatch("!(*a)*", "aa"));
+    t.true(!isMatch("!(*a)*", "bba"));
+    t.true(!isMatch("!(*a)*", "ab"));
+    t.true(!isMatch("!(*a)*", "ac"));
+    t.true(isMatch("!(*a)*", "b"));
+
+    t.true(!isMatch("!(a)*", "a"));
+    t.true(!isMatch("!(a)*", "abb"));
+    t.true(isMatch("!(a)*", "ba"));
+
+    t.true(isMatch("a!(b)*", "aa"));
+    t.true(!isMatch("a!(b)*", "ab"));
+    t.true(!isMatch("a!(b)*", "aba"));
+    t.true(isMatch("a!(b)*", "ac"));
+
+    // t.true ( isMatch ( '!(!(moo)).!(!(cow))', 'moo.cow' ) );
+
+    t.true(!isMatch("!(a|b)c", "ac"));
+    t.true(!isMatch("!(a|b)c", "bc"));
+    t.true(isMatch("!(a|b)c", "cc"));
+
+    t.true(!isMatch("!(a|b)c.!(d|e)", "ac.d"));
+    t.true(!isMatch("!(a|b)c.!(d|e)", "bc.d"));
+    t.true(!isMatch("!(a|b)c.!(d|e)", "cc.d"));
+    t.true(!isMatch("!(a|b)c.!(d|e)", "ac.e"));
+    t.true(!isMatch("!(a|b)c.!(d|e)", "bc.e"));
+    t.true(!isMatch("!(a|b)c.!(d|e)", "cc.e"));
+    t.true(!isMatch("!(a|b)c.!(d|e)", "ac.f"));
+    t.true(!isMatch("!(a|b)c.!(d|e)", "bc.f"));
+    t.true(isMatch("!(a|b)c.!(d|e)", "cc.f"));
+    t.true(isMatch("!(a|b)c.!(d|e)", "dc.g"));
+
+    // t.true ( isMatch ( '!(!(a|b)c.!(d|e))', 'ac.d' ) );
+    // t.true ( isMatch ( '!(!(a|b)c.!(d|e))', 'bc.d' ) );
+    // t.true ( !isMatch ( '!(a|b)c.!(d|e)', 'cc.d' ) );
+    // t.true ( isMatch ( '!(!(a|b)c.!(d|e))', 'cc.d' ) );
+    // t.true ( isMatch ( '!(!(a|b)c.!(d|e))', 'cc.d' ) );
+    // t.true ( isMatch ( '!(!(a|b)c.!(d|e))', 'ac.e' ) );
+    // t.true ( isMatch ( '!(!(a|b)c.!(d|e))', 'bc.e' ) );
+    // t.true ( isMatch ( '!(!(a|b)c.!(d|e))', 'cc.e' ) );
+    // t.true ( isMatch ( '!(!(a|b)c.!(d|e))', 'ac.f' ) );
+    // t.true ( isMatch ( '!(!(a|b)c.!(d|e))', 'bc.f' ) );
+    // t.true ( !isMatch ( '!(!(a|b)c.!(d|e))', 'cc.f' ) );
+    // t.true ( !isMatch ( '!(!(a|b)c.!(d|e))', 'dc.g' ) );
+
+    // t.true ( !isMatch ( '@(a|b).md', '.md' ) );
+    // t.true ( !isMatch ( '@(a|b).md', 'a.js' ) );
+    // t.true ( !isMatch ( '@(a|b).md', 'c.md' ) );
+    // t.true ( isMatch ( '@(a|b).md', 'a.md' ) );
+    // t.true ( isMatch ( '@(a|b).md', 'b.md' ) );
+
+    t.true(!isMatch("+(a|b).md", ".md"));
+    t.true(!isMatch("+(a|b).md", "a.js"));
+    t.true(!isMatch("+(a|b).md", "c.md"));
+    t.true(isMatch("+(a|b).md", "a.md"));
+    t.true(isMatch("+(a|b).md", "aa.md"));
+    t.true(isMatch("+(a|b).md", "ab.md"));
+    t.true(isMatch("+(a|b).md", "b.md"));
+    t.true(isMatch("+(a|b).md", "bb.md"));
+
+    t.true(!isMatch("*(a|b).md", "a.js"));
+    t.true(!isMatch("*(a|b).md", "c.md"));
+    t.true(isMatch("*(a|b).md", ".md"));
+    t.true(isMatch("*(a|b).md", "a.md"));
+    t.true(isMatch("*(a|b).md", "aa.md"));
+    t.true(isMatch("*(a|b).md", "ab.md"));
+    t.true(isMatch("*(a|b).md", "b.md"));
+    t.true(isMatch("*(a|b).md", "bb.md"));
+
+    t.true(!isMatch("?(a|b).md", "a.js"));
+    t.true(!isMatch("?(a|b).md", "bb.md"));
+    t.true(!isMatch("?(a|b).md", "c.md"));
+    t.true(isMatch("?(a|b).md", ".md"));
+    t.true(isMatch("?(a|ab|b).md", "a.md"));
+    t.true(isMatch("?(a|b).md", "a.md"));
+    t.true(isMatch("?(a|aa|b).md", "aa.md"));
+    t.true(isMatch("?(a|ab|b).md", "ab.md"));
+    t.true(isMatch("?(a|ab|b).md", "b.md"));
+
+    t.true(isMatch("+(a)?(b)", "ab"));
+    t.true(isMatch("+(a)?(b)", "aab"));
+    t.true(isMatch("+(a)?(b)", "aa"));
+    t.true(isMatch("+(a)?(b)", "a"));
+
+    t.true(!isMatch("a?(b*)", "ax"));
+    t.true(isMatch("?(a*|b)", "ax"));
+
+    t.true(!isMatch("a*(b*)", "ax"));
+    t.true(isMatch("*(a*|b)", "ax"));
+
+    t.true(!isMatch("a@(b*)", "ax"));
+    t.true(isMatch("@(a*|b)", "ax"));
+
+    t.true(!isMatch("a?(b*)", "ax"));
+    t.true(isMatch("?(a*|b)", "ax"));
+
+    t.true(isMatch("a!(b*)", "ax"));
+    t.true(!isMatch("!(a*|b)", "ax"));
+
+    // t.true ( isMatch ( '!(a/**)', 'a' ) );
+    // t.true ( !isMatch ( '!(a/**)', 'a/' ) );
+    // t.true ( !isMatch ( '!(a/**)', 'a/b' ) );
+    // t.true ( !isMatch ( '!(a/**)', 'a/b/c' ) );
+    // t.true ( isMatch ( '!(a/**)', 'b' ) );
+    // t.true ( isMatch ( '!(a/**)', 'b/c' ) );
+
+    t.true(isMatch("a/!(b*)", "a/a"));
+    t.true(!isMatch("a/!(b*)", "a/b"));
+    t.true(!isMatch("a/!(b/*)", "a/b/c"));
+    t.true(!isMatch("a/!(b*)", "a/b/c"));
+    t.true(isMatch("a/!(b*)", "a/c"));
+
+    t.true(isMatch("a/!(b*)/**", "a/a/"));
+    t.true(isMatch("a/!(b*)", "a/a"));
+    t.true(isMatch("a/!(b*)/**", "a/a"));
+    t.true(!isMatch("a/!(b*)/**", "a/b"));
+    t.true(!isMatch("a/!(b*)/**", "a/b/c"));
+    t.true(isMatch("a/!(b*)/**", "a/c"));
+    t.true(isMatch("a/!(b*)", "a/c"));
+    t.true(isMatch("a/!(b*)/**", "a/c/"));
+
+    t.true(isMatch("a*(z)", "a"));
+    t.true(isMatch("a*(z)", "az"));
+    t.true(isMatch("a*(z)", "azz"));
+    t.true(isMatch("a*(z)", "azzz"));
+    t.true(!isMatch("a*(z)", "abz"));
+    t.true(!isMatch("a*(z)", "cz"));
+
+    t.true(!isMatch("*(b/a)", "a/a"));
+    t.true(!isMatch("*(b/a)", "a/b"));
+    t.true(!isMatch("*(b/a)", "a/c"));
+    t.true(isMatch("*(b/a)", "b/a"));
+    t.true(!isMatch("*(b/a)", "b/b"));
+    t.true(!isMatch("*(b/a)", "b/c"));
+
+    // t.true ( !isMatch ( 'a**(z)', 'cz' ) );
+    // t.true ( isMatch ( 'a**(z)', 'abz' ) );
+    // t.true ( isMatch ( 'a**(z)', 'az' ) );
+
+    t.true(!isMatch("*(z)", "c/z/v"));
+    t.true(isMatch("*(z)", "z"));
+    t.true(!isMatch("*(z)", "zf"));
+    t.true(!isMatch("*(z)", "fz"));
+
+    t.true(!isMatch("c/*(z)/v", "c/a/v"));
+    t.true(isMatch("c/*(z)/v", "c/z/v"));
+
+    t.true(!isMatch("*.*(js).js", "a.md.js"));
+    t.true(isMatch("*.*(js).js", "a.js.js"));
+
+    t.true(!isMatch("a+(z)", "a"));
+    t.true(isMatch("a+(z)", "az"));
+    t.true(!isMatch("a+(z)", "cz"));
+    t.true(!isMatch("a+(z)", "abz"));
+    t.true(!isMatch("a+(z)", "a+z"));
+    t.true(isMatch("a++(z)", "a+z"));
+    t.true(!isMatch("a+(z)", "c+z"));
+    t.true(!isMatch("a+(z)", "a+bz"));
+    t.true(!isMatch("+(z)", "az"));
+    t.true(!isMatch("+(z)", "cz"));
+    t.true(!isMatch("+(z)", "abz"));
+    t.true(!isMatch("+(z)", "fz"));
+    t.true(isMatch("+(z)", "z"));
+    t.true(isMatch("+(z)", "zz"));
+    t.true(isMatch("c/+(z)/v", "c/z/v"));
+    t.true(isMatch("c/+(z)/v", "c/zz/v"));
+    t.true(!isMatch("c/+(z)/v", "c/a/v"));
+
+    t.true(isMatch("a??(z)", "a?z"));
+    t.true(isMatch("a??(z)", "a.z"));
+    t.true(!isMatch("a??(z)", "a/z"));
+    t.true(isMatch("a??(z)", "a?"));
+    t.true(isMatch("a??(z)", "ab"));
+    t.true(!isMatch("a??(z)", "a/"));
+
+    t.true(!isMatch("a?(z)", "a?z"));
+    t.true(!isMatch("a?(z)", "abz"));
+    t.true(!isMatch("a?(z)", "z"));
+    t.true(isMatch("a?(z)", "a"));
+    t.true(isMatch("a?(z)", "az"));
+
+    t.true(!isMatch("?(z)", "abz"));
+    t.true(!isMatch("?(z)", "az"));
+    t.true(!isMatch("?(z)", "cz"));
+    t.true(!isMatch("?(z)", "fz"));
+    t.true(!isMatch("?(z)", "zz"));
+    t.true(isMatch("?(z)", "z"));
+
+    t.true(!isMatch("c/?(z)/v", "c/a/v"));
+    t.true(!isMatch("c/?(z)/v", "c/zz/v"));
+    t.true(isMatch("c/?(z)/v", "c/z/v"));
+
+    t.true(isMatch("c/@(z)/v", "c/z/v"));
+    t.true(!isMatch("c/@(z)/v", "c/a/v"));
+    t.true(isMatch("@(*.*)", "moo.cow"));
+
+    t.true(!isMatch("a*@(z)", "cz"));
+    t.true(isMatch("a*@(z)", "abz"));
+    t.true(isMatch("a*@(z)", "az"));
+
+    t.true(!isMatch("a@(z)", "cz"));
+    t.true(!isMatch("a@(z)", "abz"));
+    t.true(isMatch("a@(z)", "az"));
+
+    t.true(!isMatch("(b|a).(a)", "aa.aa"));
+    t.true(!isMatch("(b|a).(a)", "a.bb"));
+    t.true(!isMatch("(b|a).(a)", "a.aa.a"));
+    t.true(!isMatch("(b|a).(a)", "cc.a"));
+    // t.true ( isMatch ( '(b|a).(a)', 'a.a' ) );
+    t.true(!isMatch("(b|a).(a)", "c.a"));
+    t.true(!isMatch("(b|a).(a)", "dd.aa.d"));
+    // t.true ( isMatch ( '(b|a).(a)', 'b.a' ) );
+
+    // t.true ( !isMatch ( '@(b|a).@(a)', 'aa.aa' ) );
+    // t.true ( !isMatch ( '@(b|a).@(a)', 'a.bb' ) );
+    // t.true ( !isMatch ( '@(b|a).@(a)', 'a.aa.a' ) );
+    // t.true ( !isMatch ( '@(b|a).@(a)', 'cc.a' ) );
+    // t.true ( isMatch ( '@(b|a).@(a)', 'a.a' ) );
+    // t.true ( !isMatch ( '@(b|a).@(a)', 'c.a' ) );
+    // t.true ( !isMatch ( '@(b|a).@(a)', 'dd.aa.d' ) );
+    // t.true ( isMatch ( '@(b|a).@(a)', 'b.a' ) );
+
+    // t.true ( !isMatch ( '*(0|1|3|5|7|9)', '' ) );
+
+    t.true(isMatch("*(0|1|3|5|7|9)", "137577991"));
+    t.true(!isMatch("*(0|1|3|5|7|9)", "2468"));
+
+    t.true(isMatch("*.c?(c)", "file.c"));
+    t.true(!isMatch("*.c?(c)", "file.C"));
+    t.true(isMatch("*.c?(c)", "file.cc"));
+    t.true(!isMatch("*.c?(c)", "file.ccc"));
+
+    t.true(isMatch("!(*.c|*.h|Makefile.in|config*|README)", "parse.y"));
+    t.true(!isMatch("!(*.c|*.h|Makefile.in|config*|README)", "shell.c"));
+    t.true(isMatch("!(*.c|*.h|Makefile.in|config*|README)", "Makefile"));
+    t.true(!isMatch("!(*.c|*.h|Makefile.in|config*|README)", "Makefile.in"));
+
+    t.true(!isMatch("*\\;[1-9]*([0-9])", "VMS.FILE;"));
+    t.true(!isMatch("*\\;[1-9]*([0-9])", "VMS.FILE;0"));
+    t.true(isMatch("*\\;[1-9]*([0-9])", "VMS.FILE;1"));
+    t.true(isMatch("*\\;[1-9]*([0-9])", "VMS.FILE;139"));
+    t.true(!isMatch("*\\;[1-9]*([0-9])", "VMS.FILE;1N"));
+
+    t.true(isMatch("!([*)*", "abcx"));
+    t.true(isMatch("!([*)*", "abcz"));
+    t.true(isMatch("!([*)*", "bbc"));
+
+    t.true(isMatch("!([[*])*", "abcx"));
+    t.true(isMatch("!([[*])*", "abcz"));
+    t.true(isMatch("!([[*])*", "bbc"));
+
+    t.true(isMatch("+(a|b\\[)*", "abcx"));
+    t.true(isMatch("+(a|b\\[)*", "abcz"));
+    t.true(!isMatch("+(a|b\\[)*", "bbc"));
+
+    t.true(isMatch("+(a|b[)*", "abcx"));
+    t.true(isMatch("+(a|b[)*", "abcz"));
+    t.true(!isMatch("+(a|b[)*", "bbc"));
+
+    t.true(!isMatch("[a*(]*z", "abcx"));
+    t.true(isMatch("[a*(]*z", "abcz"));
+    t.true(!isMatch("[a*(]*z", "bbc"));
+    t.true(isMatch("[a*(]*z", "aaz"));
+    t.true(isMatch("[a*(]*z", "aaaz"));
+
+    t.true(!isMatch("[a*(]*)z", "abcx"));
+    t.true(!isMatch("[a*(]*)z", "abcz"));
+    t.true(!isMatch("[a*(]*)z", "bbc"));
+
+    t.true(!isMatch("+()c", "abc"));
+    t.true(!isMatch("+()x", "abc"));
+    t.true(isMatch("+(*)c", "abc"));
+    t.true(!isMatch("+(*)x", "abc"));
+    t.true(!isMatch("no-file+(a|b)stuff", "abc"));
+    t.true(!isMatch("no-file+(a*(c)|b)stuff", "abc"));
+
+    t.true(isMatch("a+(b|c)d", "abd"));
+    t.true(isMatch("a+(b|c)d", "acd"));
+
+    t.true(!isMatch("a+(b|c)d", "abc"));
+
+    // t.true ( isMatch ( 'a!(b|B)', 'abd' ) );
+    // t.true ( isMatch ( 'a!(@(b|B))', 'acd' ) );
+    // t.true ( isMatch ( 'a!(@(b|B))', 'ac' ) );
+    // t.true ( !isMatch ( 'a!(@(b|B))', 'ab' ) );
+
+    // t.true ( !isMatch ( 'a!(@(b|B))d', 'abc' ) );
+    // t.true ( !isMatch ( 'a!(@(b|B))d', 'abd' ) );
+    // t.true ( isMatch ( 'a!(@(b|B))d', 'acd' ) );
+
+    t.true(isMatch("a[b*(foo|bar)]d", "abd"));
+    t.true(!isMatch("a[b*(foo|bar)]d", "abc"));
+    t.true(!isMatch("a[b*(foo|bar)]d", "acd"));
+
+    // t.true ( !isMatch ( 'para+([0-9])', 'para' ) );
+    // t.true ( !isMatch ( 'para?([345]|99)1', 'para381' ) );
+    // t.true ( !isMatch ( 'para*([0-9])', 'paragraph' ) );
+    // t.true ( !isMatch ( 'para@(chute|graph)', 'paramour' ) );
+    // t.true ( isMatch ( 'para*([0-9])', 'para' ) );
+    // t.true ( isMatch ( 'para!(*.[0-9])', 'para.38' ) );
+    // t.true ( isMatch ( 'para!(*.[00-09])', 'para.38' ) );
+    // t.true ( isMatch ( 'para!(*.[0-9])', 'para.graph' ) );
+    // t.true ( isMatch ( 'para*([0-9])', 'para13829383746592' ) );
+    // t.true ( isMatch ( 'para!(*.[0-9])', 'para39' ) );
+    // t.true ( isMatch ( 'para+([0-9])', 'para987346523' ) );
+    // t.true ( isMatch ( 'para?([345]|99)1', 'para991' ) );
+    // t.true ( isMatch ( 'para!(*.[0-9])', 'paragraph' ) );
+    // t.true ( isMatch ( 'para@(chute|graph)', 'paragraph' ) );
+
+    t.true(!isMatch("*(a|b[)", "foo"));
+    t.true(!isMatch("*(a|b[)", "("));
+    t.true(!isMatch("*(a|b[)", ")"));
+    t.true(!isMatch("*(a|b[)", "|"));
+    t.true(isMatch("*(a|b)", "a"));
+    t.true(isMatch("*(a|b)", "b"));
+    t.true(isMatch("*(a|b\\[)", "b["));
+    t.true(isMatch("+(a|b\\[)", "ab["));
+    t.true(!isMatch("+(a|b\\[)", "ab[cde"));
+    t.true(isMatch("+(a|b\\[)*", "ab[cde"));
+
+    // t.true ( isMatch ( '*(a|b|f)*', 'foo' ) );
+    // t.true ( isMatch ( '*(a|b|o)*', 'foo' ) );
+    // t.true ( isMatch ( '*(a|b|f|o)', 'foo' ) );
+    // t.true ( isMatch ( '\\*\\(a\\|b\\[\\)', '*(a|b[)' ) );
+    // t.true ( !isMatch ( '*(a|b)', 'foo' ) );
+    // t.true ( !isMatch ( '*(a|b\\[)', 'foo' ) );
+    // t.true ( isMatch ( '*(a|b\\[)|f*', 'foo' ) );
+
+    // t.true ( isMatch ( '@(*).@(*)', 'moo.cow' ) );
+    // t.true ( isMatch ( '*.@(a|b|@(ab|a*@(b))*@(c)d)', 'a.a' ) );
+    // t.true ( isMatch ( '*.@(a|b|@(ab|a*@(b))*@(c)d)', 'a.b' ) );
+    // t.true ( !isMatch ( '*.@(a|b|@(ab|a*@(b))*@(c)d)', 'a.c' ) );
+    // t.true ( !isMatch ( '*.@(a|b|@(ab|a*@(b))*@(c)d)', 'a.c.d' ) );
+    // t.true ( !isMatch ( '*.@(a|b|@(ab|a*@(b))*@(c)d)', 'c.c' ) );
+    // t.true ( !isMatch ( '*.@(a|b|@(ab|a*@(b))*@(c)d)', 'a.' ) );
+    // t.true ( !isMatch ( '*.@(a|b|@(ab|a*@(b))*@(c)d)', 'd.d' ) );
+    // t.true ( !isMatch ( '*.@(a|b|@(ab|a*@(b))*@(c)d)', 'e.e' ) );
+    // t.true ( !isMatch ( '*.@(a|b|@(ab|a*@(b))*@(c)d)', 'f.f' ) );
+    // t.true ( isMatch ( '*.@(a|b|@(ab|a*@(b))*@(c)d)', 'a.abcd' ) );
+
+    // t.true ( !isMatch ( '!(*.a|*.b|*.c)', 'a.a' ) );
+    // t.true ( !isMatch ( '!(*.a|*.b|*.c)', 'a.b' ) );
+    // t.true ( !isMatch ( '!(*.a|*.b|*.c)', 'a.c' ) );
+    // t.true ( isMatch ( '!(*.a|*.b|*.c)', 'a.c.d' ) );
+    // t.true ( !isMatch ( '!(*.a|*.b|*.c)', 'c.c' ) );
+    // t.true ( isMatch ( '!(*.a|*.b|*.c)', 'a.' ) );
+    // t.true ( isMatch ( '!(*.a|*.b|*.c)', 'd.d' ) );
+    // t.true ( isMatch ( '!(*.a|*.b|*.c)', 'e.e' ) );
+    // t.true ( isMatch ( '!(*.a|*.b|*.c)', 'f.f' ) );
+    // t.true ( isMatch ( '!(*.a|*.b|*.c)', 'a.abcd' ) );
+
+    t.true(isMatch("!(*.[^a-c])", "a.a"));
+    t.true(isMatch("!(*.[^a-c])", "a.b"));
+    t.true(isMatch("!(*.[^a-c])", "a.c"));
+    t.true(!isMatch("!(*.[^a-c])", "a.c.d"));
+    t.true(isMatch("!(*.[^a-c])", "c.c"));
+    t.true(isMatch("!(*.[^a-c])", "a."));
+    t.true(!isMatch("!(*.[^a-c])", "d.d"));
+    t.true(!isMatch("!(*.[^a-c])", "e.e"));
+    t.true(!isMatch("!(*.[^a-c])", "f.f"));
+    t.true(isMatch("!(*.[^a-c])", "a.abcd"));
+
+    // t.true ( !isMatch ( '!(*.[a-c])', 'a.a' ) );
+    // t.true ( !isMatch ( '!(*.[a-c])', 'a.b' ) );
+    // t.true ( !isMatch ( '!(*.[a-c])', 'a.c' ) );
+    // t.true ( isMatch ( '!(*.[a-c])', 'a.c.d' ) );
+    // t.true ( !isMatch ( '!(*.[a-c])', 'c.c' ) );
+    // t.true ( isMatch ( '!(*.[a-c])', 'a.' ) );
+    // t.true ( isMatch ( '!(*.[a-c])', 'd.d' ) );
+    // t.true ( isMatch ( '!(*.[a-c])', 'e.e' ) );
+    // t.true ( isMatch ( '!(*.[a-c])', 'f.f' ) );
+    // t.true ( isMatch ( '!(*.[a-c])', 'a.abcd' ) );
+
+    t.true(!isMatch("!(*.[a-c]*)", "a.a"));
+    t.true(!isMatch("!(*.[a-c]*)", "a.b"));
+    t.true(!isMatch("!(*.[a-c]*)", "a.c"));
+    t.true(!isMatch("!(*.[a-c]*)", "a.c.d"));
+    t.true(!isMatch("!(*.[a-c]*)", "c.c"));
+    t.true(isMatch("!(*.[a-c]*)", "a."));
+    t.true(isMatch("!(*.[a-c]*)", "d.d"));
+    t.true(isMatch("!(*.[a-c]*)", "e.e"));
+    t.true(isMatch("!(*.[a-c]*)", "f.f"));
+    t.true(!isMatch("!(*.[a-c]*)", "a.abcd"));
+
+    // t.true ( !isMatch ( '*.!(a|b|c)', 'a.a' ) );
+    // t.true ( !isMatch ( '*.!(a|b|c)', 'a.b' ) );
+    // t.true ( !isMatch ( '*.!(a|b|c)', 'a.c' ) );
+    // t.true ( isMatch ( '*.!(a|b|c)', 'a.c.d' ) );
+    // t.true ( !isMatch ( '*.!(a|b|c)', 'c.c' ) );
+    // t.true ( isMatch ( '*.!(a|b|c)', 'a.' ) );
+    // t.true ( isMatch ( '*.!(a|b|c)', 'd.d' ) );
+    // t.true ( isMatch ( '*.!(a|b|c)', 'e.e' ) );
+    // t.true ( isMatch ( '*.!(a|b|c)', 'f.f' ) );
+    // t.true ( isMatch ( '*.!(a|b|c)', 'a.abcd' ) );
+
+    t.true(isMatch("*!(.a|.b|.c)", "a.a"));
+    t.true(isMatch("*!(.a|.b|.c)", "a.b"));
+    t.true(isMatch("*!(.a|.b|.c)", "a.c"));
+    t.true(isMatch("*!(.a|.b|.c)", "a.c.d"));
+    t.true(isMatch("*!(.a|.b|.c)", "c.c"));
+    t.true(isMatch("*!(.a|.b|.c)", "a."));
+    t.true(isMatch("*!(.a|.b|.c)", "d.d"));
+    t.true(isMatch("*!(.a|.b|.c)", "e.e"));
+    t.true(isMatch("*!(.a|.b|.c)", "f.f"));
+    t.true(isMatch("*!(.a|.b|.c)", "a.abcd"));
+
+    t.true(!isMatch("!(*.[a-c])*", "a.a"));
+    t.true(!isMatch("!(*.[a-c])*", "a.b"));
+    t.true(!isMatch("!(*.[a-c])*", "a.c"));
+    t.true(!isMatch("!(*.[a-c])*", "a.c.d"));
+    t.true(!isMatch("!(*.[a-c])*", "c.c"));
+    t.true(isMatch("!(*.[a-c])*", "a."));
+    t.true(isMatch("!(*.[a-c])*", "d.d"));
+    t.true(isMatch("!(*.[a-c])*", "e.e"));
+    t.true(isMatch("!(*.[a-c])*", "f.f"));
+    t.true(!isMatch("!(*.[a-c])*", "a.abcd"));
+
+    t.true(isMatch("*!(.a|.b|.c)*", "a.a"));
+    t.true(isMatch("*!(.a|.b|.c)*", "a.b"));
+    t.true(isMatch("*!(.a|.b|.c)*", "a.c"));
+    t.true(isMatch("*!(.a|.b|.c)*", "a.c.d"));
+    t.true(isMatch("*!(.a|.b|.c)*", "c.c"));
+    t.true(isMatch("*!(.a|.b|.c)*", "a."));
+    t.true(isMatch("*!(.a|.b|.c)*", "d.d"));
+    t.true(isMatch("*!(.a|.b|.c)*", "e.e"));
+    t.true(isMatch("*!(.a|.b|.c)*", "f.f"));
+    t.true(isMatch("*!(.a|.b|.c)*", "a.abcd"));
+
+    t.true(!isMatch("*.!(a|b|c)*", "a.a"));
+    t.true(!isMatch("*.!(a|b|c)*", "a.b"));
+    t.true(!isMatch("*.!(a|b|c)*", "a.c"));
+    t.true(isMatch("*.!(a|b|c)*", "a.c.d"));
+    t.true(!isMatch("*.!(a|b|c)*", "c.c"));
+    t.true(isMatch("*.!(a|b|c)*", "a."));
+    t.true(isMatch("*.!(a|b|c)*", "d.d"));
+    t.true(isMatch("*.!(a|b|c)*", "e.e"));
+    t.true(isMatch("*.!(a|b|c)*", "f.f"));
+    t.true(!isMatch("*.!(a|b|c)*", "a.abcd"));
+
+    // t.true ( !isMatch ( '@()ef', 'def' ) );
+    // t.true ( isMatch ( '@()ef', 'ef' ) );
+
+    // t.true ( !isMatch ( '()ef', 'def' ) );
+    // t.true ( isMatch ( '()ef', 'ef' ) );
+
+    // t.true ( isMatch ( 'a\\\\\\(b', 'a\\(b' ) );
+    // t.true ( isMatch ( 'a(b', 'a(b' ) );
+    // t.true ( isMatch ( 'a\\(b', 'a(b' ) );
+    // t.true ( !isMatch ( 'a(b', 'a((b' ) );
+    // t.true ( !isMatch ( 'a(b', 'a((((b' ) );
+    // t.true ( !isMatch ( 'a(b', 'ab' ) );
+
+    t.true(isMatch("a\\(b", "a(b"));
+    t.true(!isMatch("a\\(b", "a((b"));
+    t.true(!isMatch("a\\(b", "a((((b"));
+    t.true(!isMatch("a\\(b", "ab"));
+
+    t.true(isMatch("a(*b", "a(b"));
+    t.true(isMatch("a\\(*b", "a(ab"));
+    t.true(isMatch("a(*b", "a((b"));
+    t.true(isMatch("a(*b", "a((((b"));
+    t.true(!isMatch("a(*b", "ab"));
+
+    t.true(isMatch("a\\(b", "a(b"));
+    t.true(isMatch("a\\(\\(b", "a((b"));
+    t.true(isMatch("a\\(\\(\\(\\(b", "a((((b"));
+
+    t.true(!isMatch("a\\\\(b", "a(b"));
+    t.true(!isMatch("a\\\\(b", "a((b"));
+    t.true(!isMatch("a\\\\(b", "a((((b"));
+    t.true(!isMatch("a\\\\(b", "ab"));
+
+    t.true(!isMatch("a\\\\b", "a/b"));
+    t.true(!isMatch("a\\\\b", "ab"));
+  });
+
+  // Tests adapted from "glob-match": https://github.com/devongovett/glob-match
+  // License: https://github.com/devongovett/glob-match/blob/main/LICENSE
+
+  it("basic", (t) => {
+    t.true(isMatch("abc", "abc"));
+    t.true(isMatch("*", "abc"));
+    t.true(isMatch("*", ""));
+    t.true(isMatch("**", ""));
+    t.true(isMatch("*c", "abc"));
+    t.true(!isMatch("*b", "abc"));
+    t.true(isMatch("a*", "abc"));
+    t.true(!isMatch("b*", "abc"));
+    t.true(isMatch("a*", "a"));
+    t.true(isMatch("*a", "a"));
+    t.true(isMatch("a*b*c*d*e*", "axbxcxdxe"));
+    t.true(isMatch("a*b*c*d*e*", "axbxcxdxexxx"));
+    t.true(isMatch("a*b?c*x", "abxbbxdbxebxczzx"));
+    t.true(!isMatch("a*b?c*x", "abxbbxdbxebxczzy"));
+
+    t.true(isMatch("a/*/test", "a/foo/test"));
+    t.true(!isMatch("a/*/test", "a/foo/bar/test"));
+    t.true(isMatch("a/**/test", "a/foo/test"));
+    t.true(isMatch("a/**/test", "a/foo/bar/test"));
+    t.true(isMatch("a/**/b/c", "a/foo/bar/b/c"));
+    t.true(isMatch("a\\*b", "a*b"));
+    t.true(!isMatch("a\\*b", "axb"));
+
+    t.true(isMatch("[abc]", "a"));
+    t.true(isMatch("[abc]", "b"));
+    t.true(isMatch("[abc]", "c"));
+    t.true(!isMatch("[abc]", "d"));
+    t.true(isMatch("x[abc]x", "xax"));
+    t.true(isMatch("x[abc]x", "xbx"));
+    t.true(isMatch("x[abc]x", "xcx"));
+    t.true(!isMatch("x[abc]x", "xdx"));
+    t.true(!isMatch("x[abc]x", "xay"));
+    t.true(isMatch("[?]", "?"));
+    t.true(!isMatch("[?]", "a"));
+    t.true(isMatch("[*]", "*"));
+    t.true(!isMatch("[*]", "a"));
+
+    t.true(isMatch("[a-cx]", "a"));
+    t.true(isMatch("[a-cx]", "b"));
+    t.true(isMatch("[a-cx]", "c"));
+    t.true(!isMatch("[a-cx]", "d"));
+    t.true(isMatch("[a-cx]", "x"));
+
+    t.true(!isMatch("[^abc]", "a"));
+    t.true(!isMatch("[^abc]", "b"));
+    t.true(!isMatch("[^abc]", "c"));
+    t.true(isMatch("[^abc]", "d"));
+    t.true(!isMatch("[!abc]", "a"));
+    t.true(!isMatch("[!abc]", "b"));
+    t.true(!isMatch("[!abc]", "c"));
+    t.true(isMatch("[!abc]", "d"));
+    t.true(isMatch("[\\!]", "!"));
+
+    t.true(isMatch("a*b*[cy]*d*e*", "axbxcxdxexxx"));
+    t.true(isMatch("a*b*[cy]*d*e*", "axbxyxdxexxx"));
+    t.true(isMatch("a*b*[cy]*d*e*", "axbxxxyxdxexxx"));
+
+    t.true(isMatch("test.{jpg,png}", "test.jpg"));
+    t.true(isMatch("test.{jpg,png}", "test.png"));
+    t.true(isMatch("test.{j*g,p*g}", "test.jpg"));
+    t.true(isMatch("test.{j*g,p*g}", "test.jpxxxg"));
+    t.true(isMatch("test.{j*g,p*g}", "test.jxg"));
+    t.true(!isMatch("test.{j*g,p*g}", "test.jnt"));
+    t.true(isMatch("test.{j*g,j*c}", "test.jnc"));
+    t.true(isMatch("test.{jpg,p*g}", "test.png"));
+    t.true(isMatch("test.{jpg,p*g}", "test.pxg"));
+    t.true(!isMatch("test.{jpg,p*g}", "test.pnt"));
+    t.true(isMatch("test.{jpeg,png}", "test.jpeg"));
+    t.true(!isMatch("test.{jpeg,png}", "test.jpg"));
+    t.true(isMatch("test.{jpeg,png}", "test.png"));
+    t.true(isMatch("test.{jp\\,g,png}", "test.jp,g"));
+    t.true(!isMatch("test.{jp\\,g,png}", "test.jxg"));
+    t.true(isMatch("test/{foo,bar}/baz", "test/foo/baz"));
+    t.true(isMatch("test/{foo,bar}/baz", "test/bar/baz"));
+    t.true(!isMatch("test/{foo,bar}/baz", "test/baz/baz"));
+    t.true(isMatch("test/{foo*,bar*}/baz", "test/foooooo/baz"));
+    t.true(isMatch("test/{foo*,bar*}/baz", "test/barrrrr/baz"));
+    t.true(isMatch("test/{*foo,*bar}/baz", "test/xxxxfoo/baz"));
+    t.true(isMatch("test/{*foo,*bar}/baz", "test/xxxxbar/baz"));
+    t.true(isMatch("test/{foo/**,bar}/baz", "test/bar/baz"));
+    t.true(!isMatch("test/{foo/**,bar}/baz", "test/bar/test/baz"));
+
+    t.true(!isMatch("*.txt", "some/big/path/to/the/needle.txt"));
+    t.true(
+      isMatch(
+        "some/**/needle.{js,tsx,mdx,ts,jsx,txt}",
+        "some/a/bigger/path/to/the/crazy/needle.txt",
+      ),
+    );
+    t.true(
+      isMatch("some/**/{a,b,c}/**/needle.txt", "some/foo/a/bigger/path/to/the/crazy/needle.txt"),
+    );
+    t.true(
+      !isMatch("some/**/{a,b,c}/**/needle.txt", "some/foo/d/bigger/path/to/the/crazy/needle.txt"),
+    );
+
+    t.true(isMatch("a/{a{a,b},b}", "a/aa"));
+    t.true(isMatch("a/{a{a,b},b}", "a/ab"));
+    t.true(!isMatch("a/{a{a,b},b}", "a/ac"));
+    t.true(isMatch("a/{a{a,b},b}", "a/b"));
+    t.true(!isMatch("a/{a{a,b},b}", "a/c"));
+    t.true(isMatch("a/{b,c[}]*}", "a/b"));
+    t.true(isMatch("a/{b,c[}]*}", "a/c}xx"));
+  });
+
+  it("bash", (t) => {
+    t.true(!isMatch("a*", "*"));
+    t.true(!isMatch("a*", "**"));
+    t.true(!isMatch("a*", "\\*"));
+    t.true(!isMatch("a*", "a/*"));
+    t.true(!isMatch("a*", "b"));
+    t.true(!isMatch("a*", "bc"));
+    t.true(!isMatch("a*", "bcd"));
+    t.true(!isMatch("a*", "bdir/"));
+    t.true(!isMatch("a*", "Beware"));
+    t.true(isMatch("a*", "a"));
+    t.true(isMatch("a*", "ab"));
+    t.true(isMatch("a*", "abc"));
+
+    t.true(!isMatch("\\a*", "*"));
+    t.true(!isMatch("\\a*", "**"));
+    t.true(!isMatch("\\a*", "\\*"));
+
+    t.true(isMatch("\\a*", "a"));
+    t.true(!isMatch("\\a*", "a/*"));
+    t.true(isMatch("\\a*", "abc"));
+    t.true(isMatch("\\a*", "abd"));
+    t.true(isMatch("\\a*", "abe"));
+    t.true(!isMatch("\\a*", "b"));
+    t.true(!isMatch("\\a*", "bb"));
+    t.true(!isMatch("\\a*", "bcd"));
+    t.true(!isMatch("\\a*", "bdir/"));
+    t.true(!isMatch("\\a*", "Beware"));
+    t.true(!isMatch("\\a*", "c"));
+    t.true(!isMatch("\\a*", "ca"));
+    t.true(!isMatch("\\a*", "cb"));
+    t.true(!isMatch("\\a*", "d"));
+    t.true(!isMatch("\\a*", "dd"));
+    t.true(!isMatch("\\a*", "de"));
+  });
+
+  it("bash_directories", (t) => {
+    t.true(!isMatch("b*/", "*"));
+    t.true(!isMatch("b*/", "**"));
+    t.true(!isMatch("b*/", "\\*"));
+    t.true(!isMatch("b*/", "a"));
+    t.true(!isMatch("b*/", "a/*"));
+    t.true(!isMatch("b*/", "abc"));
+    t.true(!isMatch("b*/", "abd"));
+    t.true(!isMatch("b*/", "abe"));
+    t.true(!isMatch("b*/", "b"));
+    t.true(!isMatch("b*/", "bb"));
+    t.true(!isMatch("b*/", "bcd"));
+    t.true(isMatch("b*/", "bdir/"));
+    t.true(!isMatch("b*/", "Beware"));
+    t.true(!isMatch("b*/", "c"));
+    t.true(!isMatch("b*/", "ca"));
+    t.true(!isMatch("b*/", "cb"));
+    t.true(!isMatch("b*/", "d"));
+    t.true(!isMatch("b*/", "dd"));
+    t.true(!isMatch("b*/", "de"));
+  });
+
+  it("bash_escaping", (t) => {
+    t.true(!isMatch("\\^", "*"));
+    t.true(!isMatch("\\^", "**"));
+    t.true(!isMatch("\\^", "\\*"));
+    t.true(!isMatch("\\^", "a"));
+    t.true(!isMatch("\\^", "a/*"));
+    t.true(!isMatch("\\^", "abc"));
+    t.true(!isMatch("\\^", "abd"));
+    t.true(!isMatch("\\^", "abe"));
+    t.true(!isMatch("\\^", "b"));
+    t.true(!isMatch("\\^", "bb"));
+    t.true(!isMatch("\\^", "bcd"));
+    t.true(!isMatch("\\^", "bdir/"));
+    t.true(!isMatch("\\^", "Beware"));
+    t.true(!isMatch("\\^", "c"));
+    t.true(!isMatch("\\^", "ca"));
+    t.true(!isMatch("\\^", "cb"));
+    t.true(!isMatch("\\^", "d"));
+    t.true(!isMatch("\\^", "dd"));
+    t.true(!isMatch("\\^", "de"));
+
+    t.true(isMatch("\\*", "*"));
+    t.true(!isMatch("\\*", "\\*")); // Why would this match? https://github.com/micromatch/picomatch/issues/117
+    t.true(!isMatch("\\*", "**"));
+    t.true(!isMatch("\\*", "a"));
+    t.true(!isMatch("\\*", "a/*"));
+    t.true(!isMatch("\\*", "abc"));
+    t.true(!isMatch("\\*", "abd"));
+    t.true(!isMatch("\\*", "abe"));
+    t.true(!isMatch("\\*", "b"));
+    t.true(!isMatch("\\*", "bb"));
+    t.true(!isMatch("\\*", "bcd"));
+    t.true(!isMatch("\\*", "bdir/"));
+    t.true(!isMatch("\\*", "Beware"));
+    t.true(!isMatch("\\*", "c"));
+    t.true(!isMatch("\\*", "ca"));
+    t.true(!isMatch("\\*", "cb"));
+    t.true(!isMatch("\\*", "d"));
+    t.true(!isMatch("\\*", "dd"));
+    t.true(!isMatch("\\*", "de"));
+
+    t.true(!isMatch("a\\*", "*"));
+    t.true(!isMatch("a\\*", "**"));
+    t.true(!isMatch("a\\*", "\\*"));
+    t.true(!isMatch("a\\*", "a"));
+    t.true(!isMatch("a\\*", "a/*"));
+    t.true(!isMatch("a\\*", "abc"));
+    t.true(!isMatch("a\\*", "abd"));
+    t.true(!isMatch("a\\*", "abe"));
+    t.true(!isMatch("a\\*", "b"));
+    t.true(!isMatch("a\\*", "bb"));
+    t.true(!isMatch("a\\*", "bcd"));
+    t.true(!isMatch("a\\*", "bdir/"));
+    t.true(!isMatch("a\\*", "Beware"));
+    t.true(!isMatch("a\\*", "c"));
+    t.true(!isMatch("a\\*", "ca"));
+    t.true(!isMatch("a\\*", "cb"));
+    t.true(!isMatch("a\\*", "d"));
+    t.true(!isMatch("a\\*", "dd"));
+    t.true(!isMatch("a\\*", "de"));
+
+    t.true(isMatch("*q*", "aqa"));
+    t.true(isMatch("*q*", "aaqaa"));
+    t.true(!isMatch("*q*", "*"));
+    t.true(!isMatch("*q*", "**"));
+    t.true(!isMatch("*q*", "\\*"));
+    t.true(!isMatch("*q*", "a"));
+    t.true(!isMatch("*q*", "a/*"));
+    t.true(!isMatch("*q*", "abc"));
+    t.true(!isMatch("*q*", "abd"));
+    t.true(!isMatch("*q*", "abe"));
+    t.true(!isMatch("*q*", "b"));
+    t.true(!isMatch("*q*", "bb"));
+    t.true(!isMatch("*q*", "bcd"));
+    t.true(!isMatch("*q*", "bdir/"));
+    t.true(!isMatch("*q*", "Beware"));
+    t.true(!isMatch("*q*", "c"));
+    t.true(!isMatch("*q*", "ca"));
+    t.true(!isMatch("*q*", "cb"));
+    t.true(!isMatch("*q*", "d"));
+    t.true(!isMatch("*q*", "dd"));
+    t.true(!isMatch("*q*", "de"));
+
+    t.true(isMatch("\\**", "*"));
+    t.true(isMatch("\\**", "**"));
+    t.true(!isMatch("\\**", "\\*"));
+    t.true(!isMatch("\\**", "a"));
+    t.true(!isMatch("\\**", "a/*"));
+    t.true(!isMatch("\\**", "abc"));
+    t.true(!isMatch("\\**", "abd"));
+    t.true(!isMatch("\\**", "abe"));
+    t.true(!isMatch("\\**", "b"));
+    t.true(!isMatch("\\**", "bb"));
+    t.true(!isMatch("\\**", "bcd"));
+    t.true(!isMatch("\\**", "bdir/"));
+    t.true(!isMatch("\\**", "Beware"));
+    t.true(!isMatch("\\**", "c"));
+    t.true(!isMatch("\\**", "ca"));
+    t.true(!isMatch("\\**", "cb"));
+    t.true(!isMatch("\\**", "d"));
+    t.true(!isMatch("\\**", "dd"));
+    t.true(!isMatch("\\**", "de"));
+  });
+
+  it("bash_classes", (t) => {
+    t.true(!isMatch("a*[^c]", "*"));
+    t.true(!isMatch("a*[^c]", "**"));
+    t.true(!isMatch("a*[^c]", "\\*"));
+    t.true(!isMatch("a*[^c]", "a"));
+    t.true(!isMatch("a*[^c]", "a/*"));
+    t.true(!isMatch("a*[^c]", "abc"));
+    t.true(isMatch("a*[^c]", "abd"));
+    t.true(isMatch("a*[^c]", "abe"));
+    t.true(!isMatch("a*[^c]", "b"));
+    t.true(!isMatch("a*[^c]", "bb"));
+    t.true(!isMatch("a*[^c]", "bcd"));
+    t.true(!isMatch("a*[^c]", "bdir/"));
+    t.true(!isMatch("a*[^c]", "Beware"));
+    t.true(!isMatch("a*[^c]", "c"));
+    t.true(!isMatch("a*[^c]", "ca"));
+    t.true(!isMatch("a*[^c]", "cb"));
+    t.true(!isMatch("a*[^c]", "d"));
+    t.true(!isMatch("a*[^c]", "dd"));
+    t.true(!isMatch("a*[^c]", "de"));
+    t.true(!isMatch("a*[^c]", "baz"));
+    t.true(!isMatch("a*[^c]", "bzz"));
+    t.true(!isMatch("a*[^c]", "BZZ"));
+    t.true(!isMatch("a*[^c]", "beware"));
+    t.true(!isMatch("a*[^c]", "BewAre"));
+
+    t.true(isMatch("a[X-]b", "a-b"));
+    t.true(isMatch("a[X-]b", "aXb"));
+
+    t.true(!isMatch("[a-y]*[^c]", "*"));
+    t.true(isMatch("[a-y]*[^c]", "a*"));
+    t.true(!isMatch("[a-y]*[^c]", "**"));
+    t.true(!isMatch("[a-y]*[^c]", "\\*"));
+    t.true(!isMatch("[a-y]*[^c]", "a"));
+    t.true(isMatch("[a-y]*[^c]", "a123b"));
+    t.true(!isMatch("[a-y]*[^c]", "a123c"));
+    t.true(isMatch("[a-y]*[^c]", "ab"));
+    t.true(!isMatch("[a-y]*[^c]", "a/*"));
+    t.true(!isMatch("[a-y]*[^c]", "abc"));
+    t.true(isMatch("[a-y]*[^c]", "abd"));
+    t.true(isMatch("[a-y]*[^c]", "abe"));
+    t.true(!isMatch("[a-y]*[^c]", "b"));
+    t.true(isMatch("[a-y]*[^c]", "bd"));
+    t.true(isMatch("[a-y]*[^c]", "bb"));
+    t.true(isMatch("[a-y]*[^c]", "bcd"));
+    t.true(isMatch("[a-y]*[^c]", "bdir/"));
+    t.true(!isMatch("[a-y]*[^c]", "Beware"));
+    t.true(!isMatch("[a-y]*[^c]", "c"));
+    t.true(isMatch("[a-y]*[^c]", "ca"));
+    t.true(isMatch("[a-y]*[^c]", "cb"));
+    t.true(!isMatch("[a-y]*[^c]", "d"));
+    t.true(isMatch("[a-y]*[^c]", "dd"));
+    t.true(isMatch("[a-y]*[^c]", "dd"));
+    t.true(isMatch("[a-y]*[^c]", "dd"));
+    t.true(isMatch("[a-y]*[^c]", "de"));
+    t.true(isMatch("[a-y]*[^c]", "baz"));
+    t.true(isMatch("[a-y]*[^c]", "bzz"));
+    t.true(isMatch("[a-y]*[^c]", "bzz"));
+    t.true(!isMatch("bzz", "[a-y]*[^c]"));
+    t.true(!isMatch("[a-y]*[^c]", "BZZ"));
+    t.true(isMatch("[a-y]*[^c]", "beware"));
+    t.true(!isMatch("[a-y]*[^c]", "BewAre"));
+
+    t.true(isMatch("a\\*b/*", "a*b/ooo"));
+    t.true(isMatch("a\\*?/*", "a*b/ooo"));
+
+    t.true(!isMatch("a[b]c", "*"));
+    t.true(!isMatch("a[b]c", "**"));
+    t.true(!isMatch("a[b]c", "\\*"));
+    t.true(!isMatch("a[b]c", "a"));
+    t.true(!isMatch("a[b]c", "a/*"));
+    t.true(isMatch("a[b]c", "abc"));
+    t.true(!isMatch("a[b]c", "abd"));
+    t.true(!isMatch("a[b]c", "abe"));
+    t.true(!isMatch("a[b]c", "b"));
+    t.true(!isMatch("a[b]c", "bb"));
+    t.true(!isMatch("a[b]c", "bcd"));
+    t.true(!isMatch("a[b]c", "bdir/"));
+    t.true(!isMatch("a[b]c", "Beware"));
+    t.true(!isMatch("a[b]c", "c"));
+    t.true(!isMatch("a[b]c", "ca"));
+    t.true(!isMatch("a[b]c", "cb"));
+    t.true(!isMatch("a[b]c", "d"));
+    t.true(!isMatch("a[b]c", "dd"));
+    t.true(!isMatch("a[b]c", "de"));
+    t.true(!isMatch("a[b]c", "baz"));
+    t.true(!isMatch("a[b]c", "bzz"));
+    t.true(!isMatch("a[b]c", "BZZ"));
+    t.true(!isMatch("a[b]c", "beware"));
+    t.true(!isMatch("a[b]c", "BewAre"));
+
+    t.true(!isMatch('a["b"]c', "*"));
+    t.true(!isMatch('a["b"]c', "**"));
+    t.true(!isMatch('a["b"]c', "\\*"));
+    t.true(!isMatch('a["b"]c', "a"));
+    t.true(!isMatch('a["b"]c', "a/*"));
+    t.true(isMatch('a["b"]c', "abc"));
+    t.true(!isMatch('a["b"]c', "abd"));
+    t.true(!isMatch('a["b"]c', "abe"));
+    t.true(!isMatch('a["b"]c', "b"));
+    t.true(!isMatch('a["b"]c', "bb"));
+    t.true(!isMatch('a["b"]c', "bcd"));
+    t.true(!isMatch('a["b"]c', "bdir/"));
+    t.true(!isMatch('a["b"]c', "Beware"));
+    t.true(!isMatch('a["b"]c', "c"));
+    t.true(!isMatch('a["b"]c', "ca"));
+    t.true(!isMatch('a["b"]c', "cb"));
+    t.true(!isMatch('a["b"]c', "d"));
+    t.true(!isMatch('a["b"]c', "dd"));
+    t.true(!isMatch('a["b"]c', "de"));
+    t.true(!isMatch('a["b"]c', "baz"));
+    t.true(!isMatch('a["b"]c', "bzz"));
+    t.true(!isMatch('a["b"]c', "BZZ"));
+    t.true(!isMatch('a["b"]c', "beware"));
+    t.true(!isMatch('a["b"]c', "BewAre"));
+
+    t.true(!isMatch("a[\\\\b]c", "*"));
+    t.true(!isMatch("a[\\\\b]c", "**"));
+    t.true(!isMatch("a[\\\\b]c", "\\*"));
+    t.true(!isMatch("a[\\\\b]c", "a"));
+    t.true(!isMatch("a[\\\\b]c", "a/*"));
+    t.true(isMatch("a[\\\\b]c", "abc"));
+    t.true(!isMatch("a[\\\\b]c", "abd"));
+    t.true(!isMatch("a[\\\\b]c", "abe"));
+    t.true(!isMatch("a[\\\\b]c", "b"));
+    t.true(!isMatch("a[\\\\b]c", "bb"));
+    t.true(!isMatch("a[\\\\b]c", "bcd"));
+    t.true(!isMatch("a[\\\\b]c", "bdir/"));
+    t.true(!isMatch("a[\\\\b]c", "Beware"));
+    t.true(!isMatch("a[\\\\b]c", "c"));
+    t.true(!isMatch("a[\\\\b]c", "ca"));
+    t.true(!isMatch("a[\\\\b]c", "cb"));
+    t.true(!isMatch("a[\\\\b]c", "d"));
+    t.true(!isMatch("a[\\\\b]c", "dd"));
+    t.true(!isMatch("a[\\\\b]c", "de"));
+    t.true(!isMatch("a[\\\\b]c", "baz"));
+    t.true(!isMatch("a[\\\\b]c", "bzz"));
+    t.true(!isMatch("a[\\\\b]c", "BZZ"));
+    t.true(!isMatch("a[\\\\b]c", "beware"));
+    t.true(!isMatch("a[\\\\b]c", "BewAre"));
+
+    t.true(!isMatch("a[\\b]c", "*"));
+    t.true(!isMatch("a[\\b]c", "**"));
+    t.true(!isMatch("a[\\b]c", "\\*"));
+    t.true(!isMatch("a[\\b]c", "a"));
+    t.true(!isMatch("a[\\b]c", "a/*"));
+    t.true(!isMatch("a[\\b]c", "abc"));
+    t.true(!isMatch("a[\\b]c", "abd"));
+    t.true(!isMatch("a[\\b]c", "abe"));
+    t.true(!isMatch("a[\\b]c", "b"));
+    t.true(!isMatch("a[\\b]c", "bb"));
+    t.true(!isMatch("a[\\b]c", "bcd"));
+    t.true(!isMatch("a[\\b]c", "bdir/"));
+    t.true(!isMatch("a[\\b]c", "Beware"));
+    t.true(!isMatch("a[\\b]c", "c"));
+    t.true(!isMatch("a[\\b]c", "ca"));
+    t.true(!isMatch("a[\\b]c", "cb"));
+    t.true(!isMatch("a[\\b]c", "d"));
+    t.true(!isMatch("a[\\b]c", "dd"));
+    t.true(!isMatch("a[\\b]c", "de"));
+    t.true(!isMatch("a[\\b]c", "baz"));
+    t.true(!isMatch("a[\\b]c", "bzz"));
+    t.true(!isMatch("a[\\b]c", "BZZ"));
+    t.true(!isMatch("a[\\b]c", "beware"));
+    t.true(!isMatch("a[\\b]c", "BewAre"));
+
+    t.true(!isMatch("a[b-d]c", "*"));
+    t.true(!isMatch("a[b-d]c", "**"));
+    t.true(!isMatch("a[b-d]c", "\\*"));
+    t.true(!isMatch("a[b-d]c", "a"));
+    t.true(!isMatch("a[b-d]c", "a/*"));
+    t.true(isMatch("a[b-d]c", "abc"));
+    t.true(!isMatch("a[b-d]c", "abd"));
+    t.true(!isMatch("a[b-d]c", "abe"));
+    t.true(!isMatch("a[b-d]c", "b"));
+    t.true(!isMatch("a[b-d]c", "bb"));
+    t.true(!isMatch("a[b-d]c", "bcd"));
+    t.true(!isMatch("a[b-d]c", "bdir/"));
+    t.true(!isMatch("a[b-d]c", "Beware"));
+    t.true(!isMatch("a[b-d]c", "c"));
+    t.true(!isMatch("a[b-d]c", "ca"));
+    t.true(!isMatch("a[b-d]c", "cb"));
+    t.true(!isMatch("a[b-d]c", "d"));
+    t.true(!isMatch("a[b-d]c", "dd"));
+    t.true(!isMatch("a[b-d]c", "de"));
+    t.true(!isMatch("a[b-d]c", "baz"));
+    t.true(!isMatch("a[b-d]c", "bzz"));
+    t.true(!isMatch("a[b-d]c", "BZZ"));
+    t.true(!isMatch("a[b-d]c", "beware"));
+    t.true(!isMatch("a[b-d]c", "BewAre"));
+
+    t.true(!isMatch("a?c", "*"));
+    t.true(!isMatch("a?c", "**"));
+    t.true(!isMatch("a?c", "\\*"));
+    t.true(!isMatch("a?c", "a"));
+    t.true(!isMatch("a?c", "a/*"));
+    t.true(isMatch("a?c", "abc"));
+    t.true(!isMatch("a?c", "abd"));
+    t.true(!isMatch("a?c", "abe"));
+    t.true(!isMatch("a?c", "b"));
+    t.true(!isMatch("a?c", "bb"));
+    t.true(!isMatch("a?c", "bcd"));
+    t.true(!isMatch("a?c", "bdir/"));
+    t.true(!isMatch("a?c", "Beware"));
+    t.true(!isMatch("a?c", "c"));
+    t.true(!isMatch("a?c", "ca"));
+    t.true(!isMatch("a?c", "cb"));
+    t.true(!isMatch("a?c", "d"));
+    t.true(!isMatch("a?c", "dd"));
+    t.true(!isMatch("a?c", "de"));
+    t.true(!isMatch("a?c", "baz"));
+    t.true(!isMatch("a?c", "bzz"));
+    t.true(!isMatch("a?c", "BZZ"));
+    t.true(!isMatch("a?c", "beware"));
+    t.true(!isMatch("a?c", "BewAre"));
+
+    t.true(isMatch("*/man*/bash.*", "man/man1/bash.1"));
+
+    t.true(isMatch("[^a-c]*", "*"));
+    t.true(isMatch("[^a-c]*", "**"));
+    t.true(!isMatch("[^a-c]*", "a"));
+    t.true(!isMatch("[^a-c]*", "a/*"));
+    t.true(!isMatch("[^a-c]*", "abc"));
+    t.true(!isMatch("[^a-c]*", "abd"));
+    t.true(!isMatch("[^a-c]*", "abe"));
+    t.true(!isMatch("[^a-c]*", "b"));
+    t.true(!isMatch("[^a-c]*", "bb"));
+    t.true(!isMatch("[^a-c]*", "bcd"));
+    t.true(!isMatch("[^a-c]*", "bdir/"));
+    t.true(isMatch("[^a-c]*", "Beware"));
+    t.true(isMatch("[^a-c]*", "Beware"));
+    t.true(!isMatch("[^a-c]*", "c"));
+    t.true(!isMatch("[^a-c]*", "ca"));
+    t.true(!isMatch("[^a-c]*", "cb"));
+    t.true(isMatch("[^a-c]*", "d"));
+    t.true(isMatch("[^a-c]*", "dd"));
+    t.true(isMatch("[^a-c]*", "de"));
+    t.true(!isMatch("[^a-c]*", "baz"));
+    t.true(!isMatch("[^a-c]*", "bzz"));
+    t.true(isMatch("[^a-c]*", "BZZ"));
+    t.true(!isMatch("[^a-c]*", "beware"));
+    t.true(isMatch("[^a-c]*", "BewAre"));
+  });
+
+  it("bash_wildmatch", (t) => {
+    t.true(!isMatch("a[]-]b", "aab"));
+    t.true(!isMatch("[ten]", "ten"));
+    t.true(isMatch("]", "]"));
+    // t.true ( isMatch ( "a[]-]b", "a-b" ) );
+    // t.true ( isMatch ( "a[]-]b", "a]b" ) );
+    // t.true ( isMatch ( "a[]]b", "a]b" ) );
+    // t.true ( isMatch ( "a[\\]a\\-]b", "aab" ) );
+    t.true(isMatch("t[a-g]n", "ten"));
+    t.true(isMatch("t[^a-g]n", "ton"));
+  });
+
+  it("bash_slashmatch", (t) => {
+    t.true(!isMatch("f[^eiu][^eiu][^eiu][^eiu][^eiu]r", "foo/bar"));
+    t.true(isMatch("foo[/]bar", "foo/bar"));
+    t.true(isMatch("f[^eiu][^eiu][^eiu][^eiu][^eiu]r", "foo-bar"));
+  });
+
+  it("bash_extra_stars", (t) => {
+    t.true(!isMatch("a**c", "bbc"));
+    t.true(isMatch("a**c", "abc"));
+    t.true(!isMatch("a**c", "bbd"));
+
+    t.true(!isMatch("a***c", "bbc"));
+    t.true(isMatch("a***c", "abc"));
+    t.true(!isMatch("a***c", "bbd"));
+
+    t.true(!isMatch("a*****?c", "bbc"));
+    t.true(isMatch("a*****?c", "abc"));
+    t.true(!isMatch("a*****?c", "bbc"));
+
+    t.true(isMatch("?*****??", "bbc"));
+    t.true(isMatch("?*****??", "abc"));
+
+    t.true(isMatch("*****??", "bbc"));
+    t.true(isMatch("*****??", "abc"));
+
+    t.true(isMatch("?*****?c", "bbc"));
+    t.true(isMatch("?*****?c", "abc"));
+
+    t.true(isMatch("?***?****c", "bbc"));
+    t.true(isMatch("?***?****c", "abc"));
+    t.true(!isMatch("?***?****c", "bbd"));
+
+    t.true(isMatch("?***?****?", "bbc"));
+    t.true(isMatch("?***?****?", "abc"));
+
+    t.true(isMatch("?***?****", "bbc"));
+    t.true(isMatch("?***?****", "abc"));
+
+    t.true(isMatch("*******c", "bbc"));
+    t.true(isMatch("*******c", "abc"));
+
+    t.true(isMatch("*******?", "bbc"));
+    t.true(isMatch("*******?", "abc"));
+
+    t.true(isMatch("a*cd**?**??k", "abcdecdhjk"));
+    t.true(isMatch("a**?**cd**?**??k", "abcdecdhjk"));
+    t.true(isMatch("a**?**cd**?**??k***", "abcdecdhjk"));
+    t.true(isMatch("a**?**cd**?**??***k", "abcdecdhjk"));
+    t.true(isMatch("a**?**cd**?**??***k**", "abcdecdhjk"));
+    t.true(isMatch("a****c**?**??*****", "abcdecdhjk"));
+  });
+
+  it("stars", (t) => {
+    t.true(!isMatch("*.js", "a/b/c/z.js"));
+    t.true(!isMatch("*.js", "a/b/z.js"));
+    t.true(!isMatch("*.js", "a/z.js"));
+    t.true(isMatch("*.js", "z.js"));
+
+    t.true(isMatch("*/*", "a/.ab"));
+    t.true(isMatch("*", ".ab"));
+
+    t.true(isMatch("z*.js", "z.js"));
+    t.true(isMatch("*/*", "a/z"));
+    t.true(isMatch("*/z*.js", "a/z.js"));
+    t.true(isMatch("a/z*.js", "a/z.js"));
+
+    t.true(isMatch("*", "ab"));
+    t.true(isMatch("*", "abc"));
+
+    t.true(!isMatch("f*", "bar"));
+    t.true(!isMatch("*r", "foo"));
+    t.true(!isMatch("b*", "foo"));
+    t.true(!isMatch("*", "foo/bar"));
+    t.true(isMatch("*c", "abc"));
+    t.true(isMatch("a*", "abc"));
+    t.true(isMatch("a*c", "abc"));
+    t.true(isMatch("*r", "bar"));
+    t.true(isMatch("b*", "bar"));
+    t.true(isMatch("f*", "foo"));
+
+    t.true(isMatch("*abc*", "one abc two"));
+    t.true(isMatch("a*b", "a         b"));
+
+    t.true(!isMatch("*a*", "foo"));
+    t.true(isMatch("*a*", "bar"));
+    t.true(isMatch("*abc*", "oneabctwo"));
+    t.true(!isMatch("*-bc-*", "a-b.c-d"));
+    t.true(isMatch("*-*.*-*", "a-b.c-d"));
+    t.true(isMatch("*-b*c-*", "a-b.c-d"));
+    t.true(isMatch("*-b.c-*", "a-b.c-d"));
+    t.true(isMatch("*.*", "a-b.c-d"));
+    t.true(isMatch("*.*-*", "a-b.c-d"));
+    t.true(isMatch("*.*-d", "a-b.c-d"));
+    t.true(isMatch("*.c-*", "a-b.c-d"));
+    t.true(isMatch("*b.*d", "a-b.c-d"));
+    t.true(isMatch("a*.c*", "a-b.c-d"));
+    t.true(isMatch("a-*.*-d", "a-b.c-d"));
+    t.true(isMatch("*.*", "a.b"));
+    t.true(isMatch("*.b", "a.b"));
+    t.true(isMatch("a.*", "a.b"));
+    t.true(isMatch("a.b", "a.b"));
+
+    t.true(!isMatch("**-bc-**", "a-b.c-d"));
+    t.true(isMatch("**-**.**-**", "a-b.c-d"));
+    t.true(isMatch("**-b**c-**", "a-b.c-d"));
+    t.true(isMatch("**-b.c-**", "a-b.c-d"));
+    t.true(isMatch("**.**", "a-b.c-d"));
+    t.true(isMatch("**.**-**", "a-b.c-d"));
+    t.true(isMatch("**.**-d", "a-b.c-d"));
+    t.true(isMatch("**.c-**", "a-b.c-d"));
+    t.true(isMatch("**b.**d", "a-b.c-d"));
+    t.true(isMatch("a**.c**", "a-b.c-d"));
+    t.true(isMatch("a-**.**-d", "a-b.c-d"));
+    t.true(isMatch("**.**", "a.b"));
+    t.true(isMatch("**.b", "a.b"));
+    t.true(isMatch("a.**", "a.b"));
+    t.true(isMatch("a.b", "a.b"));
+
+    t.true(isMatch("*/*", "/ab"));
+    t.true(isMatch(".", "."));
+    t.true(!isMatch("a/", "a/.b"));
+    t.true(isMatch("/*", "/ab"));
+    t.true(isMatch("/??", "/ab"));
+    t.true(isMatch("/?b", "/ab"));
+    t.true(isMatch("/*", "/cd"));
+    t.true(isMatch("a", "a"));
+    t.true(isMatch("a/.*", "a/.b"));
+    t.true(isMatch("?/?", "a/b"));
+    t.true(isMatch("a/**/j/**/z/*.md", "a/b/c/d/e/j/n/p/o/z/c.md"));
+    t.true(isMatch("a/**/z/*.md", "a/b/c/d/e/z/c.md"));
+    t.true(isMatch("a/b/c/*.md", "a/b/c/xyz.md"));
+    t.true(isMatch("a/b/c/*.md", "a/b/c/xyz.md"));
+    t.true(isMatch("a/*/z/.a", "a/b/z/.a"));
+    t.true(!isMatch("bz", "a/b/z/.a"));
+    t.true(isMatch("a/**/c/*.md", "a/bb.bb/aa/b.b/aa/c/xyz.md"));
+    t.true(isMatch("a/**/c/*.md", "a/bb.bb/aa/bb/aa/c/xyz.md"));
+    t.true(isMatch("a/*/c/*.md", "a/bb.bb/c/xyz.md"));
+    t.true(isMatch("a/*/c/*.md", "a/bb/c/xyz.md"));
+    t.true(isMatch("a/*/c/*.md", "a/bbbb/c/xyz.md"));
+    t.true(isMatch("*", "aaa"));
+    t.true(isMatch("*", "ab"));
+    t.true(isMatch("ab", "ab"));
+
+    t.true(!isMatch("*/*/*", "aaa"));
+    t.true(!isMatch("*/*/*", "aaa/bb/aa/rr"));
+    t.true(!isMatch("aaa*", "aaa/bba/ccc"));
+    t.true(!isMatch("aaa**", "aaa/bba/ccc"));
+    t.true(!isMatch("aaa/*", "aaa/bba/ccc"));
+    t.true(!isMatch("aaa/*ccc", "aaa/bba/ccc"));
+    t.true(!isMatch("aaa/*z", "aaa/bba/ccc"));
+    t.true(!isMatch("*/*/*", "aaa/bbb"));
+    t.true(!isMatch("*/*jk*/*i", "ab/zzz/ejkl/hi"));
+    t.true(isMatch("*/*/*", "aaa/bba/ccc"));
+    t.true(isMatch("aaa/**", "aaa/bba/ccc"));
+    t.true(isMatch("aaa/*", "aaa/bbb"));
+    t.true(isMatch("*/*z*/*/*i", "ab/zzz/ejkl/hi"));
+    t.true(isMatch("*j*i", "abzzzejklhi"));
+
+    t.true(isMatch("*", "a"));
+    t.true(isMatch("*", "b"));
+    t.true(!isMatch("*", "a/a"));
+    t.true(!isMatch("*", "a/a/a"));
+    t.true(!isMatch("*", "a/a/b"));
+    t.true(!isMatch("*", "a/a/a/a"));
+    t.true(!isMatch("*", "a/a/a/a/a"));
+
+    t.true(!isMatch("*/*", "a"));
+    t.true(isMatch("*/*", "a/a"));
+    t.true(!isMatch("*/*", "a/a/a"));
+
+    t.true(!isMatch("*/*/*", "a"));
+    t.true(!isMatch("*/*/*", "a/a"));
+    t.true(isMatch("*/*/*", "a/a/a"));
+    t.true(!isMatch("*/*/*", "a/a/a/a"));
+
+    t.true(!isMatch("*/*/*/*", "a"));
+    t.true(!isMatch("*/*/*/*", "a/a"));
+    t.true(!isMatch("*/*/*/*", "a/a/a"));
+    t.true(isMatch("*/*/*/*", "a/a/a/a"));
+    t.true(!isMatch("*/*/*/*", "a/a/a/a/a"));
+
+    t.true(!isMatch("*/*/*/*/*", "a"));
+    t.true(!isMatch("*/*/*/*/*", "a/a"));
+    t.true(!isMatch("*/*/*/*/*", "a/a/a"));
+    t.true(!isMatch("*/*/*/*/*", "a/a/b"));
+    t.true(!isMatch("*/*/*/*/*", "a/a/a/a"));
+    t.true(isMatch("*/*/*/*/*", "a/a/a/a/a"));
+    t.true(!isMatch("*/*/*/*/*", "a/a/a/a/a/a"));
+
+    t.true(!isMatch("a/*", "a"));
+    t.true(isMatch("a/*", "a/a"));
+    t.true(!isMatch("a/*", "a/a/a"));
+    t.true(!isMatch("a/*", "a/a/a/a"));
+    t.true(!isMatch("a/*", "a/a/a/a/a"));
+
+    t.true(!isMatch("a/*/*", "a"));
+    t.true(!isMatch("a/*/*", "a/a"));
+    t.true(isMatch("a/*/*", "a/a/a"));
+    t.true(!isMatch("a/*/*", "b/a/a"));
+    t.true(!isMatch("a/*/*", "a/a/a/a"));
+    t.true(!isMatch("a/*/*", "a/a/a/a/a"));
+
+    t.true(!isMatch("a/*/*/*", "a"));
+    t.true(!isMatch("a/*/*/*", "a/a"));
+    t.true(!isMatch("a/*/*/*", "a/a/a"));
+    t.true(isMatch("a/*/*/*", "a/a/a/a"));
+    t.true(!isMatch("a/*/*/*", "a/a/a/a/a"));
+
+    t.true(!isMatch("a/*/*/*/*", "a"));
+    t.true(!isMatch("a/*/*/*/*", "a/a"));
+    t.true(!isMatch("a/*/*/*/*", "a/a/a"));
+    t.true(!isMatch("a/*/*/*/*", "a/a/b"));
+    t.true(!isMatch("a/*/*/*/*", "a/a/a/a"));
+    t.true(isMatch("a/*/*/*/*", "a/a/a/a/a"));
+
+    t.true(!isMatch("a/*/a", "a"));
+    t.true(!isMatch("a/*/a", "a/a"));
+    t.true(isMatch("a/*/a", "a/a/a"));
+    t.true(!isMatch("a/*/a", "a/a/b"));
+    t.true(!isMatch("a/*/a", "a/a/a/a"));
+    t.true(!isMatch("a/*/a", "a/a/a/a/a"));
+
+    t.true(!isMatch("a/*/b", "a"));
+    t.true(!isMatch("a/*/b", "a/a"));
+    t.true(!isMatch("a/*/b", "a/a/a"));
+    t.true(isMatch("a/*/b", "a/a/b"));
+    t.true(!isMatch("a/*/b", "a/a/a/a"));
+    t.true(!isMatch("a/*/b", "a/a/a/a/a"));
+
+    t.true(!isMatch("*/**/a", "a"));
+    t.true(!isMatch("*/**/a", "a/a/b"));
+    t.true(isMatch("*/**/a", "a/a"));
+    t.true(isMatch("*/**/a", "a/a/a"));
+    t.true(isMatch("*/**/a", "a/a/a/a"));
+    t.true(isMatch("*/**/a", "a/a/a/a/a"));
+
+    t.true(!isMatch("*/", "a"));
+    t.true(!isMatch("*/*", "a"));
+    t.true(!isMatch("a/*", "a"));
+    // t.true ( !isMatch ( "*/*", "a/" ) );
+    // t.true ( !isMatch ( "a/*", "a/" ) );
+    t.true(!isMatch("*", "a/a"));
+    t.true(!isMatch("*/", "a/a"));
+    t.true(!isMatch("*/", "a/x/y"));
+    t.true(!isMatch("*/*", "a/x/y"));
+    t.true(!isMatch("a/*", "a/x/y"));
+    t.true(isMatch("*", "a/"));
+    t.true(isMatch("*", "a"));
+    t.true(isMatch("*/", "a/"));
+    t.true(isMatch("*{,/}", "a/"));
+    t.true(isMatch("*/*", "a/a"));
+    t.true(isMatch("a/*", "a/a"));
+
+    t.true(!isMatch("a/**/*.txt", "a.txt"));
+    t.true(isMatch("a/**/*.txt", "a/x/y.txt"));
+    t.true(!isMatch("a/**/*.txt", "a/x/y/z"));
+
+    t.true(!isMatch("a/*.txt", "a.txt"));
+    t.true(isMatch("a/*.txt", "a/b.txt"));
+    t.true(!isMatch("a/*.txt", "a/x/y.txt"));
+    t.true(!isMatch("a/*.txt", "a/x/y/z"));
+
+    t.true(isMatch("a*.txt", "a.txt"));
+    t.true(!isMatch("a*.txt", "a/b.txt"));
+    t.true(!isMatch("a*.txt", "a/x/y.txt"));
+    t.true(!isMatch("a*.txt", "a/x/y/z"));
+
+    t.true(isMatch("*.txt", "a.txt"));
+    t.true(!isMatch("*.txt", "a/b.txt"));
+    t.true(!isMatch("*.txt", "a/x/y.txt"));
+    t.true(!isMatch("*.txt", "a/x/y/z"));
+
+    t.true(!isMatch("a*", "a/b"));
+    t.true(!isMatch("a/**/b", "a/a/bb"));
+    t.true(!isMatch("a/**/b", "a/bb"));
+
+    t.true(!isMatch("*/**", "foo"));
+    t.true(!isMatch("**/", "foo/bar"));
+    t.true(!isMatch("**/*/", "foo/bar"));
+    t.true(!isMatch("*/*/", "foo/bar"));
+
+    t.true(isMatch("**/..", "/home/foo/.."));
+    t.true(isMatch("**/a", "a"));
+    t.true(isMatch("**", "a/a"));
+    t.true(isMatch("a/**", "a/a"));
+    t.true(isMatch("a/**", "a/"));
+    t.true(isMatch("a/**", "a"));
+    t.true(!isMatch("**/", "a/a"));
+    t.true(isMatch("**/a/**", "a"));
+    t.true(isMatch("a/**", "a"));
+    t.true(!isMatch("**/", "a/a"));
+    t.true(isMatch("*/**/a", "a/a"));
+    t.true(isMatch("a/**", "a"));
+    t.true(isMatch("*/**", "foo/"));
+    t.true(isMatch("**/*", "foo/bar"));
+    t.true(isMatch("*/*", "foo/bar"));
+    t.true(isMatch("*/**", "foo/bar"));
+    t.true(isMatch("**/", "foo/bar/"));
+    t.true(isMatch("**/*", "foo/bar/"));
+    t.true(isMatch("**/*/", "foo/bar/"));
+    t.true(isMatch("*/**", "foo/bar/"));
+    t.true(isMatch("*/*/", "foo/bar/"));
+
+    t.true(!isMatch("*/foo", "bar/baz/foo"));
+    t.true(!isMatch("**/bar/*", "deep/foo/bar"));
+    t.true(!isMatch("*/bar/**", "deep/foo/bar/baz/x"));
+    t.true(!isMatch("/*", "ef"));
+    t.true(!isMatch("foo?bar", "foo/bar"));
+    t.true(!isMatch("**/bar*", "foo/bar/baz"));
+    t.true(!isMatch("**/bar**", "foo/bar/baz"));
+    t.true(!isMatch("foo**bar", "foo/baz/bar"));
+    t.true(!isMatch("foo*bar", "foo/baz/bar"));
+    t.true(isMatch("foo/**", "foo"));
+    t.true(isMatch("/*", "/ab"));
+    t.true(isMatch("/*", "/cd"));
+    t.true(isMatch("/*", "/ef"));
+    t.true(isMatch("a/**/j/**/z/*.md", "a/b/j/c/z/x.md"));
+    t.true(isMatch("a/**/j/**/z/*.md", "a/j/z/x.md"));
+
+    t.true(isMatch("**/foo", "bar/baz/foo"));
+    t.true(isMatch("**/bar/*", "deep/foo/bar/baz"));
+    t.true(isMatch("**/bar/**", "deep/foo/bar/baz/"));
+    t.true(isMatch("**/bar/*/*", "deep/foo/bar/baz/x"));
+    t.true(isMatch("foo/**/**/bar", "foo/b/a/z/bar"));
+    t.true(isMatch("foo/**/bar", "foo/b/a/z/bar"));
+    t.true(isMatch("foo/**/**/bar", "foo/bar"));
+    t.true(isMatch("foo/**/bar", "foo/bar"));
+    t.true(isMatch("*/bar/**", "foo/bar/baz/x"));
+    t.true(isMatch("foo/**/**/bar", "foo/baz/bar"));
+    t.true(isMatch("foo/**/bar", "foo/baz/bar"));
+    t.true(isMatch("**/foo", "XXX/foo"));
+  });
+
+  it("globstars", (t) => {
+    t.true(isMatch("**/*.js", "a/b/c/d.js"));
+    t.true(isMatch("**/*.js", "a/b/c.js"));
+    t.true(isMatch("**/*.js", "a/b.js"));
+    t.true(isMatch("a/b/**/*.js", "a/b/c/d/e/f.js"));
+    t.true(isMatch("a/b/**/*.js", "a/b/c/d/e.js"));
+    t.true(isMatch("a/b/c/**/*.js", "a/b/c/d.js"));
+    t.true(isMatch("a/b/**/*.js", "a/b/c/d.js"));
+    t.true(isMatch("a/b/**/*.js", "a/b/d.js"));
+    t.true(!isMatch("a/b/**/*.js", "a/d.js"));
+    t.true(!isMatch("a/b/**/*.js", "d.js"));
+
+    t.true(!isMatch("**c", "a/b/c"));
+    t.true(!isMatch("a/**c", "a/b/c"));
+    t.true(!isMatch("a/**z", "a/b/c"));
+    t.true(!isMatch("a/**b**/c", "a/b/c/b/c"));
+    t.true(!isMatch("a/b/c**/*.js", "a/b/c/d/e.js"));
+    t.true(isMatch("a/**/b/**/c", "a/b/c/b/c"));
+    t.true(isMatch("a/**b**/c", "a/aba/c"));
+    t.true(isMatch("a/**b**/c", "a/b/c"));
+    t.true(isMatch("a/b/c**/*.js", "a/b/c/d.js"));
+
+    t.true(!isMatch("a/**/*", "a"));
+    t.true(!isMatch("a/**/**/*", "a"));
+    t.true(!isMatch("a/**/**/**/*", "a"));
+    t.true(isMatch("**/a", "a/"));
+    // t.true ( !isMatch ( "a/**/*", "a/" ) );
+    // t.true ( !isMatch ( "a/**/**/*", "a/" ) );
+    // t.true ( !isMatch ( "a/**/**/**/*", "a/" ) );
+    t.true(!isMatch("**/a", "a/b"));
+    t.true(!isMatch("a/**/j/**/z/*.md", "a/b/c/j/e/z/c.txt"));
+    t.true(!isMatch("a/**/b", "a/bb"));
+    t.true(!isMatch("**/a", "a/c"));
+    t.true(!isMatch("**/a", "a/b"));
+    t.true(!isMatch("**/a", "a/x/y"));
+    t.true(!isMatch("**/a", "a/b/c/d"));
+    t.true(isMatch("**", "a"));
+    t.true(isMatch("**/a", "a"));
+    t.true(isMatch("a/**", "a"));
+    t.true(isMatch("**", "a/"));
+    t.true(isMatch("**/a/**", "a/"));
+    t.true(isMatch("a/**", "a/"));
+    t.true(isMatch("a/**/**", "a/"));
+    t.true(isMatch("**/a", "a/a"));
+    t.true(isMatch("**", "a/b"));
+    t.true(isMatch("*/*", "a/b"));
+    t.true(isMatch("a/**", "a/b"));
+    t.true(isMatch("a/**/*", "a/b"));
+    t.true(isMatch("a/**/**/*", "a/b"));
+    t.true(isMatch("a/**/**/**/*", "a/b"));
+    t.true(isMatch("a/**/b", "a/b"));
+    t.true(isMatch("**", "a/b/c"));
+    t.true(isMatch("**/*", "a/b/c"));
+    t.true(isMatch("**/**", "a/b/c"));
+    t.true(isMatch("*/**", "a/b/c"));
+    t.true(isMatch("a/**", "a/b/c"));
+    t.true(isMatch("a/**/*", "a/b/c"));
+    t.true(isMatch("a/**/**/*", "a/b/c"));
+    t.true(isMatch("a/**/**/**/*", "a/b/c"));
+    t.true(isMatch("**", "a/b/c/d"));
+    t.true(isMatch("a/**", "a/b/c/d"));
+    t.true(isMatch("a/**/*", "a/b/c/d"));
+    t.true(isMatch("a/**/**/*", "a/b/c/d"));
+    t.true(isMatch("a/**/**/**/*", "a/b/c/d"));
+    t.true(isMatch("a/b/**/c/**/*.*", "a/b/c/d.e"));
+    t.true(isMatch("a/**/f/*.md", "a/b/c/d/e/f/g.md"));
+    t.true(isMatch("a/**/f/**/k/*.md", "a/b/c/d/e/f/g/h/i/j/k/l.md"));
+    t.true(isMatch("a/b/c/*.md", "a/b/c/def.md"));
+    t.true(isMatch("a/*/c/*.md", "a/bb.bb/c/ddd.md"));
+    t.true(isMatch("a/**/f/*.md", "a/bb.bb/cc/d.d/ee/f/ggg.md"));
+    t.true(isMatch("a/**/f/*.md", "a/bb.bb/cc/dd/ee/f/ggg.md"));
+    t.true(isMatch("a/*/c/*.md", "a/bb/c/ddd.md"));
+    t.true(isMatch("a/*/c/*.md", "a/bbbb/c/ddd.md"));
+
+    t.true(isMatch("foo/bar/**/one/**/*.*", "foo/bar/baz/one/image.png"));
+    t.true(isMatch("foo/bar/**/one/**/*.*", "foo/bar/baz/one/two/image.png"));
+    t.true(isMatch("foo/bar/**/one/**/*.*", "foo/bar/baz/one/two/three/image.png"));
+    t.true(!isMatch("a/b/**/f", "a/b/c/d/"));
+    t.true(isMatch("a/**", "a"));
+    t.true(isMatch("**", "a"));
+    t.true(isMatch("a{,/**}", "a"));
+    t.true(isMatch("**", "a/"));
+    t.true(isMatch("a/**", "a/"));
+    t.true(isMatch("**", "a/b/c/d"));
+    t.true(isMatch("**", "a/b/c/d/"));
+    t.true(isMatch("**/**", "a/b/c/d/"));
+    t.true(isMatch("**/b/**", "a/b/c/d/"));
+    t.true(isMatch("a/b/**", "a/b/c/d/"));
+    t.true(isMatch("a/b/**/", "a/b/c/d/"));
+    t.true(isMatch("a/b/**/c/**/", "a/b/c/d/"));
+    t.true(isMatch("a/b/**/c/**/d/", "a/b/c/d/"));
+    t.true(isMatch("a/b/**/**/*.*", "a/b/c/d/e.f"));
+    t.true(isMatch("a/b/**/*.*", "a/b/c/d/e.f"));
+    t.true(isMatch("a/b/**/c/**/d/*.*", "a/b/c/d/e.f"));
+    t.true(isMatch("a/b/**/d/**/*.*", "a/b/c/d/e.f"));
+    t.true(isMatch("a/b/**/d/**/*.*", "a/b/c/d/g/e.f"));
+    t.true(isMatch("a/b/**/d/**/*.*", "a/b/c/d/g/g/e.f"));
+    t.true(isMatch("a/b-*/**/z.js", "a/b-c/z.js"));
+    t.true(isMatch("a/b-*/**/z.js", "a/b-c/d/e/z.js"));
+
+    t.true(isMatch("*/*", "a/b"));
+    t.true(isMatch("a/b/c/*.md", "a/b/c/xyz.md"));
+    t.true(isMatch("a/*/c/*.md", "a/bb.bb/c/xyz.md"));
+    t.true(isMatch("a/*/c/*.md", "a/bb/c/xyz.md"));
+    t.true(isMatch("a/*/c/*.md", "a/bbbb/c/xyz.md"));
+
+    t.true(isMatch("**/*", "a/b/c"));
+    t.true(isMatch("**/**", "a/b/c"));
+    t.true(isMatch("*/**", "a/b/c"));
+    t.true(isMatch("a/**/j/**/z/*.md", "a/b/c/d/e/j/n/p/o/z/c.md"));
+    t.true(isMatch("a/**/z/*.md", "a/b/c/d/e/z/c.md"));
+    t.true(isMatch("a/**/c/*.md", "a/bb.bb/aa/b.b/aa/c/xyz.md"));
+    t.true(isMatch("a/**/c/*.md", "a/bb.bb/aa/bb/aa/c/xyz.md"));
+    t.true(!isMatch("a/**/j/**/z/*.md", "a/b/c/j/e/z/c.txt"));
+    t.true(!isMatch("a/b/**/c{d,e}/**/xyz.md", "a/b/c/xyz.md"));
+    t.true(!isMatch("a/b/**/c{d,e}/**/xyz.md", "a/b/d/xyz.md"));
+    t.true(!isMatch("a/**/", "a/b"));
+    t.true(isMatch("**/*", "a/b/.js/c.txt"));
+    t.true(!isMatch("a/**/", "a/b/c/d"));
+    t.true(!isMatch("a/**/", "a/bb"));
+    t.true(!isMatch("a/**/", "a/cb"));
+    t.true(isMatch("/**", "/a/b"));
+    t.true(isMatch("**/*", "a.b"));
+    t.true(isMatch("**/*", "a.js"));
+    t.true(isMatch("**/*.js", "a.js"));
+    t.true(isMatch("a/**/", "a/"));
+    t.true(isMatch("**/*.js", "a/a.js"));
+    t.true(isMatch("**/*.js", "a/a/b.js"));
+    t.true(isMatch("a/**/b", "a/b"));
+    t.true(isMatch("a/**b", "a/b"));
+    t.true(isMatch("**/*.md", "a/b.md"));
+    t.true(isMatch("**/*", "a/b/c.js"));
+    t.true(isMatch("**/*", "a/b/c.txt"));
+    t.true(isMatch("a/**/", "a/b/c/d/"));
+    t.true(isMatch("**/*", "a/b/c/d/a.js"));
+    t.true(isMatch("a/b/**/*.js", "a/b/c/z.js"));
+    t.true(isMatch("a/b/**/*.js", "a/b/z.js"));
+    t.true(isMatch("**/*", "ab"));
+    t.true(isMatch("**/*", "ab/c"));
+    t.true(isMatch("**/*", "ab/c/d"));
+    t.true(isMatch("**/*", "abc.js"));
+
+    t.true(!isMatch("**/", "a"));
+    t.true(!isMatch("**/a/*", "a"));
+    t.true(!isMatch("**/a/*/*", "a"));
+    t.true(!isMatch("*/a/**", "a"));
+    t.true(!isMatch("a/**/*", "a"));
+    t.true(!isMatch("a/**/**/*", "a"));
+    t.true(!isMatch("**/", "a/b"));
+    t.true(!isMatch("**/b/*", "a/b"));
+    t.true(!isMatch("**/b/*/*", "a/b"));
+    t.true(!isMatch("b/**", "a/b"));
+    t.true(!isMatch("**/", "a/b/c"));
+    t.true(!isMatch("**/**/b", "a/b/c"));
+    t.true(!isMatch("**/b", "a/b/c"));
+    t.true(!isMatch("**/b/*/*", "a/b/c"));
+    t.true(!isMatch("b/**", "a/b/c"));
+    t.true(!isMatch("**/", "a/b/c/d"));
+    t.true(!isMatch("**/d/*", "a/b/c/d"));
+    t.true(!isMatch("b/**", "a/b/c/d"));
+    t.true(isMatch("**", "a"));
+    t.true(isMatch("**/**", "a"));
+    t.true(isMatch("**/**/*", "a"));
+    t.true(isMatch("**/**/a", "a"));
+    t.true(isMatch("**/a", "a"));
+    t.true(isMatch("**/a/**", "a"));
+    t.true(isMatch("a/**", "a"));
+    t.true(isMatch("**", "a/b"));
+    t.true(isMatch("**/**", "a/b"));
+    t.true(isMatch("**/**/*", "a/b"));
+    t.true(isMatch("**/**/b", "a/b"));
+    t.true(isMatch("**/b", "a/b"));
+    t.true(isMatch("**/b/**", "a/b"));
+    t.true(isMatch("*/b/**", "a/b"));
+    t.true(isMatch("a/**", "a/b"));
+    t.true(isMatch("a/**/*", "a/b"));
+    t.true(isMatch("a/**/**/*", "a/b"));
+    t.true(isMatch("**", "a/b/c"));
+    t.true(isMatch("**/**", "a/b/c"));
+    t.true(isMatch("**/**/*", "a/b/c"));
+    t.true(isMatch("**/b/*", "a/b/c"));
+    t.true(isMatch("**/b/**", "a/b/c"));
+    t.true(isMatch("*/b/**", "a/b/c"));
+    t.true(isMatch("a/**", "a/b/c"));
+    t.true(isMatch("a/**/*", "a/b/c"));
+    t.true(isMatch("a/**/**/*", "a/b/c"));
+    t.true(isMatch("**", "a/b/c/d"));
+    t.true(isMatch("**/**", "a/b/c/d"));
+    t.true(isMatch("**/**/*", "a/b/c/d"));
+    t.true(isMatch("**/**/d", "a/b/c/d"));
+    t.true(isMatch("**/b/**", "a/b/c/d"));
+    t.true(isMatch("**/b/*/*", "a/b/c/d"));
+    t.true(isMatch("**/d", "a/b/c/d"));
+    t.true(isMatch("*/b/**", "a/b/c/d"));
+    t.true(isMatch("a/**", "a/b/c/d"));
+    t.true(isMatch("a/**/*", "a/b/c/d"));
+    t.true(isMatch("a/**/**/*", "a/b/c/d"));
+  });
+
+  it("utf8", (t) => {
+    t.true(isMatch("フ*/**/*", "フォルダ/aaa.js"));
+    t.true(isMatch("フォ*/**/*", "フォルダ/aaa.js"));
+    t.true(isMatch("フォル*/**/*", "フォルダ/aaa.js"));
+    t.true(isMatch("フ*ル*/**/*", "フォルダ/aaa.js"));
+    t.true(isMatch("フォルダ/**/*", "フォルダ/aaa.js"));
+  });
+
+  it("negation", (t) => {
+    t.true(!isMatch("!*", "abc"));
+    t.true(!isMatch("!abc", "abc"));
+    t.true(!isMatch("*!.md", "bar.md"));
+    t.true(!isMatch("foo!.md", "bar.md"));
+    t.true(!isMatch("\\!*!*.md", "foo!.md"));
+    t.true(!isMatch("\\!*!*.md", "foo!bar.md"));
+    t.true(isMatch("*!*.md", "!foo!.md"));
+    t.true(isMatch("\\!*!*.md", "!foo!.md"));
+    t.true(isMatch("!*foo", "abc"));
+    t.true(isMatch("!foo*", "abc"));
+    t.true(isMatch("!xyz", "abc"));
+    t.true(isMatch("*!*.*", "ba!r.js"));
+    t.true(isMatch("*.md", "bar.md"));
+    t.true(isMatch("*!*.*", "foo!.md"));
+    t.true(isMatch("*!*.md", "foo!.md"));
+    t.true(isMatch("*!.md", "foo!.md"));
+    t.true(isMatch("*.md", "foo!.md"));
+    t.true(isMatch("foo!.md", "foo!.md"));
+    t.true(isMatch("*!*.md", "foo!bar.md"));
+    t.true(isMatch("*b*.md", "foobar.md"));
+
+    t.true(!isMatch("a!!b", "a"));
+    t.true(!isMatch("a!!b", "aa"));
+    t.true(!isMatch("a!!b", "a/b"));
+    t.true(!isMatch("a!!b", "a!b"));
+    t.true(isMatch("a!!b", "a!!b"));
+    t.true(!isMatch("a!!b", "a/!!/b"));
+
+    t.true(!isMatch("!a/b", "a/b"));
+    t.true(isMatch("!a/b", "a"));
+    t.true(isMatch("!a/b", "a.b"));
+    t.true(isMatch("!a/b", "a/a"));
+    t.true(isMatch("!a/b", "a/c"));
+    t.true(isMatch("!a/b", "b/a"));
+    t.true(isMatch("!a/b", "b/b"));
+    t.true(isMatch("!a/b", "b/c"));
+
+    t.true(!isMatch("!abc", "abc"));
+    t.true(isMatch("!!abc", "abc"));
+    t.true(!isMatch("!!!abc", "abc"));
+    t.true(isMatch("!!!!abc", "abc"));
+    t.true(!isMatch("!!!!!abc", "abc"));
+    t.true(isMatch("!!!!!!abc", "abc"));
+    t.true(!isMatch("!!!!!!!abc", "abc"));
+    t.true(isMatch("!!!!!!!!abc", "abc"));
+
+    // t.true ( !isMatch ( "!(*/*)", "a/a" ) );
+    // t.true ( !isMatch ( "!(*/*)", "a/b" ) );
+    // t.true ( !isMatch ( "!(*/*)", "a/c" ) );
+    // t.true ( !isMatch ( "!(*/*)", "b/a" ) );
+    // t.true ( !isMatch ( "!(*/*)", "b/b" ) );
+    // t.true ( !isMatch ( "!(*/*)", "b/c" ) );
+    // t.true ( !isMatch ( "!(*/b)", "a/b" ) );
+    // t.true ( !isMatch ( "!(*/b)", "b/b" ) );
+    // t.true ( !isMatch ( "!(a/b)", "a/b" ) );
+    t.true(!isMatch("!*", "a"));
+    t.true(!isMatch("!*", "a.b"));
+    t.true(!isMatch("!*/*", "a/a"));
+    t.true(!isMatch("!*/*", "a/b"));
+    t.true(!isMatch("!*/*", "a/c"));
+    t.true(!isMatch("!*/*", "b/a"));
+    t.true(!isMatch("!*/*", "b/b"));
+    t.true(!isMatch("!*/*", "b/c"));
+    t.true(!isMatch("!*/b", "a/b"));
+    t.true(!isMatch("!*/b", "b/b"));
+    t.true(!isMatch("!*/c", "a/c"));
+    t.true(!isMatch("!*/c", "a/c"));
+    t.true(!isMatch("!*/c", "b/c"));
+    t.true(!isMatch("!*/c", "b/c"));
+    t.true(!isMatch("!*a*", "bar"));
+    t.true(!isMatch("!*a*", "fab"));
+    t.true(isMatch("!a/(*)", "a/a"));
+    t.true(isMatch("!a/(*)", "a/b"));
+    t.true(isMatch("!a/(*)", "a/c"));
+    t.true(isMatch("!a/(b)", "a/b"));
+    t.true(!isMatch("!a/*", "a/a"));
+    t.true(!isMatch("!a/*", "a/b"));
+    t.true(!isMatch("!a/*", "a/c"));
+    t.true(!isMatch("!f*b", "fab"));
+    t.true(isMatch("!(*/*)", "a"));
+    t.true(isMatch("!(*/*)", "a.b"));
+    t.true(isMatch("!(*/b)", "a"));
+    t.true(isMatch("!(*/b)", "a.b"));
+    t.true(isMatch("!(*/b)", "a/a"));
+    t.true(isMatch("!(*/b)", "a/c"));
+    t.true(isMatch("!(*/b)", "b/a"));
+    t.true(isMatch("!(*/b)", "b/c"));
+    t.true(isMatch("!(a/b)", "a"));
+    t.true(isMatch("!(a/b)", "a.b"));
+    t.true(isMatch("!(a/b)", "a/a"));
+    t.true(isMatch("!(a/b)", "a/c"));
+    t.true(isMatch("!(a/b)", "b/a"));
+    t.true(isMatch("!(a/b)", "b/b"));
+    t.true(isMatch("!(a/b)", "b/c"));
+    t.true(isMatch("!*", "a/a"));
+    t.true(isMatch("!*", "a/b"));
+    t.true(isMatch("!*", "a/c"));
+    t.true(isMatch("!*", "b/a"));
+    t.true(isMatch("!*", "b/b"));
+    t.true(isMatch("!*", "b/c"));
+    t.true(isMatch("!*/*", "a"));
+    t.true(isMatch("!*/*", "a.b"));
+    t.true(isMatch("!*/b", "a"));
+    t.true(isMatch("!*/b", "a.b"));
+    t.true(isMatch("!*/b", "a/a"));
+    t.true(isMatch("!*/b", "a/c"));
+    t.true(isMatch("!*/b", "b/a"));
+    t.true(isMatch("!*/b", "b/c"));
+    t.true(isMatch("!*/c", "a"));
+    t.true(isMatch("!*/c", "a.b"));
+    t.true(isMatch("!*/c", "a/a"));
+    t.true(isMatch("!*/c", "a/b"));
+    t.true(isMatch("!*/c", "b/a"));
+    t.true(isMatch("!*/c", "b/b"));
+    t.true(isMatch("!*a*", "foo"));
+    t.true(isMatch("!a/(*)", "a"));
+    t.true(isMatch("!a/(*)", "a.b"));
+    t.true(isMatch("!a/(*)", "b/a"));
+    t.true(isMatch("!a/(*)", "b/b"));
+    t.true(isMatch("!a/(*)", "b/c"));
+    t.true(isMatch("!a/(b)", "a"));
+    t.true(isMatch("!a/(b)", "a.b"));
+    t.true(isMatch("!a/(b)", "a/a"));
+    t.true(isMatch("!a/(b)", "a/c"));
+    t.true(isMatch("!a/(b)", "b/a"));
+    t.true(isMatch("!a/(b)", "b/b"));
+    t.true(isMatch("!a/(b)", "b/c"));
+    t.true(isMatch("!a/*", "a"));
+    t.true(isMatch("!a/*", "a.b"));
+    t.true(isMatch("!a/*", "b/a"));
+    t.true(isMatch("!a/*", "b/b"));
+    t.true(isMatch("!a/*", "b/c"));
+    t.true(isMatch("!f*b", "bar"));
+    t.true(isMatch("!f*b", "foo"));
+
+    t.true(!isMatch("!.md", ".md"));
+    t.true(isMatch("!**/*.md", "a.js"));
+    t.true(!isMatch("!**/*.md", "b.md"));
+    t.true(isMatch("!**/*.md", "c.txt"));
+    t.true(isMatch("!*.md", "a.js"));
+    t.true(!isMatch("!*.md", "b.md"));
+    t.true(isMatch("!*.md", "c.txt"));
+    t.true(!isMatch("!*.md", "abc.md"));
+    t.true(isMatch("!*.md", "abc.txt"));
+    t.true(!isMatch("!*.md", "foo.md"));
+    t.true(isMatch("!.md", "foo.md"));
+
+    t.true(isMatch("!*.md", "a.js"));
+    t.true(isMatch("!*.md", "b.txt"));
+    t.true(!isMatch("!*.md", "c.md"));
+    t.true(!isMatch("!a/*/a.js", "a/a/a.js"));
+    t.true(!isMatch("!a/*/a.js", "a/b/a.js"));
+    t.true(!isMatch("!a/*/a.js", "a/c/a.js"));
+    t.true(!isMatch("!a/*/*/a.js", "a/a/a/a.js"));
+    t.true(isMatch("!a/*/*/a.js", "b/a/b/a.js"));
+    t.true(isMatch("!a/*/*/a.js", "c/a/c/a.js"));
+    t.true(!isMatch("!a/a*.txt", "a/a.txt"));
+    t.true(isMatch("!a/a*.txt", "a/b.txt"));
+    t.true(isMatch("!a/a*.txt", "a/c.txt"));
+    t.true(!isMatch("!a.a*.txt", "a.a.txt"));
+    t.true(isMatch("!a.a*.txt", "a.b.txt"));
+    t.true(isMatch("!a.a*.txt", "a.c.txt"));
+    t.true(!isMatch("!a/*.txt", "a/a.txt"));
+    t.true(!isMatch("!a/*.txt", "a/b.txt"));
+    t.true(!isMatch("!a/*.txt", "a/c.txt"));
+
+    t.true(isMatch("!*.md", "a.js"));
+    t.true(isMatch("!*.md", "b.txt"));
+    t.true(!isMatch("!*.md", "c.md"));
+    t.true(!isMatch("!**/a.js", "a/a/a.js"));
+    t.true(!isMatch("!**/a.js", "a/b/a.js"));
+    t.true(!isMatch("!**/a.js", "a/c/a.js"));
+    t.true(isMatch("!**/a.js", "a/a/b.js"));
+    t.true(!isMatch("!a/**/a.js", "a/a/a/a.js"));
+    t.true(isMatch("!a/**/a.js", "b/a/b/a.js"));
+    t.true(isMatch("!a/**/a.js", "c/a/c/a.js"));
+    t.true(isMatch("!**/*.md", "a/b.js"));
+    t.true(isMatch("!**/*.md", "a.js"));
+    t.true(!isMatch("!**/*.md", "a/b.md"));
+    t.true(!isMatch("!**/*.md", "a.md"));
+    t.true(!isMatch("**/*.md", "a/b.js"));
+    t.true(!isMatch("**/*.md", "a.js"));
+    t.true(isMatch("**/*.md", "a/b.md"));
+    t.true(isMatch("**/*.md", "a.md"));
+    t.true(isMatch("!**/*.md", "a/b.js"));
+    t.true(isMatch("!**/*.md", "a.js"));
+    t.true(!isMatch("!**/*.md", "a/b.md"));
+    t.true(!isMatch("!**/*.md", "a.md"));
+    t.true(isMatch("!*.md", "a/b.js"));
+    t.true(isMatch("!*.md", "a.js"));
+    t.true(isMatch("!*.md", "a/b.md"));
+    t.true(!isMatch("!*.md", "a.md"));
+    t.true(isMatch("!**/*.md", "a.js"));
+    t.true(!isMatch("!**/*.md", "b.md"));
+    t.true(isMatch("!**/*.md", "c.txt"));
+  });
+
+  it("question_mark", (t) => {
+    t.true(isMatch("?", "a"));
+    t.true(!isMatch("?", "aa"));
+    t.true(!isMatch("?", "ab"));
+    t.true(!isMatch("?", "aaa"));
+    t.true(!isMatch("?", "abcdefg"));
+
+    t.true(!isMatch("??", "a"));
+    t.true(isMatch("??", "aa"));
+    t.true(isMatch("??", "ab"));
+    t.true(!isMatch("??", "aaa"));
+    t.true(!isMatch("??", "abcdefg"));
+
+    t.true(!isMatch("???", "a"));
+    t.true(!isMatch("???", "aa"));
+    t.true(!isMatch("???", "ab"));
+    t.true(isMatch("???", "aaa"));
+    t.true(!isMatch("???", "abcdefg"));
+
+    t.true(!isMatch("a?c", "aaa"));
+    t.true(isMatch("a?c", "aac"));
+    t.true(isMatch("a?c", "abc"));
+    t.true(!isMatch("ab?", "a"));
+    t.true(!isMatch("ab?", "aa"));
+    t.true(!isMatch("ab?", "ab"));
+    t.true(!isMatch("ab?", "ac"));
+    t.true(!isMatch("ab?", "abcd"));
+    t.true(!isMatch("ab?", "abbb"));
+    t.true(isMatch("a?b", "acb"));
+
+    t.true(!isMatch("a/?/c/?/e.md", "a/bb/c/dd/e.md"));
+    t.true(isMatch("a/??/c/??/e.md", "a/bb/c/dd/e.md"));
+    t.true(!isMatch("a/??/c.md", "a/bbb/c.md"));
+    t.true(isMatch("a/?/c.md", "a/b/c.md"));
+    t.true(isMatch("a/?/c/?/e.md", "a/b/c/d/e.md"));
+    t.true(!isMatch("a/?/c/???/e.md", "a/b/c/d/e.md"));
+    t.true(isMatch("a/?/c/???/e.md", "a/b/c/zzz/e.md"));
+    t.true(!isMatch("a/?/c.md", "a/bb/c.md"));
+    t.true(isMatch("a/??/c.md", "a/bb/c.md"));
+    t.true(isMatch("a/???/c.md", "a/bbb/c.md"));
+    t.true(isMatch("a/????/c.md", "a/bbbb/c.md"));
+  });
+
+  it("braces", (t) => {
+    t.true(isMatch("{a,b,c}", "a"));
+    t.true(isMatch("{a,b,c}", "b"));
+    t.true(isMatch("{a,b,c}", "c"));
+    t.true(!isMatch("{a,b,c}", "aa"));
+    t.true(!isMatch("{a,b,c}", "bb"));
+    t.true(!isMatch("{a,b,c}", "cc"));
+
+    t.true(isMatch("a/{a,b}", "a/a"));
+    t.true(isMatch("a/{a,b}", "a/b"));
+    t.true(!isMatch("a/{a,b}", "a/c"));
+    t.true(!isMatch("a/{a,b}", "b/b"));
+    t.true(!isMatch("a/{a,b,c}", "b/b"));
+    t.true(isMatch("a/{a,b,c}", "a/c"));
+    t.true(isMatch("a{b,bc}.txt", "abc.txt"));
+
+    t.true(isMatch("foo[{a,b}]baz", "foo{baz"));
+
+    t.true(!isMatch("a{,b}.txt", "abc.txt"));
+    t.true(!isMatch("a{a,b,}.txt", "abc.txt"));
+    t.true(!isMatch("a{b,}.txt", "abc.txt"));
+    t.true(isMatch("a{,b}.txt", "a.txt"));
+    t.true(isMatch("a{b,}.txt", "a.txt"));
+    t.true(isMatch("a{a,b,}.txt", "aa.txt"));
+    t.true(isMatch("a{a,b,}.txt", "aa.txt"));
+    t.true(isMatch("a{,b}.txt", "ab.txt"));
+    t.true(isMatch("a{b,}.txt", "ab.txt"));
+
+    t.true(isMatch("{a/,}a/**", "a"));
+    t.true(isMatch("a{a,b/}*.txt", "aa.txt"));
+    t.true(isMatch("a{a,b/}*.txt", "ab/.txt"));
+    t.true(isMatch("a{a,b/}*.txt", "ab/a.txt"));
+    t.true(isMatch("{a/,}a/**", "a/"));
+    t.true(isMatch("{a/,}a/**", "a/a/"));
+    t.true(isMatch("{a/,}a/**", "a/a"));
+    t.true(isMatch("{a/,}a/**", "a/a/a"));
+    t.true(isMatch("{a/,}a/**", "a/a/"));
+    t.true(isMatch("{a/,}a/**", "a/a/a/"));
+    t.true(isMatch("{a/,}b/**", "a/b/a/"));
+    t.true(isMatch("{a/,}b/**", "b/a/"));
+    t.true(isMatch("a{,/}*.txt", "a.txt"));
+    t.true(isMatch("a{,/}*.txt", "ab.txt"));
+    t.true(isMatch("a{,/}*.txt", "a/b.txt"));
+    t.true(isMatch("a{,/}*.txt", "a/ab.txt"));
+
+    t.true(isMatch("a{,.*{foo,db},\\(bar\\)}.txt", "a.txt"));
+    t.true(!isMatch("a{,.*{foo,db},\\(bar\\)}.txt", "adb.txt"));
+    t.true(isMatch("a{,.*{foo,db},\\(bar\\)}.txt", "a.db.txt"));
+
+    t.true(isMatch("a{,*.{foo,db},\\(bar\\)}.txt", "a.txt"));
+    t.true(!isMatch("a{,*.{foo,db},\\(bar\\)}.txt", "adb.txt"));
+    t.true(isMatch("a{,*.{foo,db},\\(bar\\)}.txt", "a.db.txt"));
+
+    t.true(isMatch("a{,.*{foo,db},\\(bar\\)}", "a"));
+    t.true(!isMatch("a{,.*{foo,db},\\(bar\\)}", "adb"));
+    t.true(isMatch("a{,.*{foo,db},\\(bar\\)}", "a.db"));
+
+    t.true(isMatch("a{,*.{foo,db},\\(bar\\)}", "a"));
+    t.true(!isMatch("a{,*.{foo,db},\\(bar\\)}", "adb"));
+    t.true(isMatch("a{,*.{foo,db},\\(bar\\)}", "a.db"));
+
+    t.true(!isMatch("{,.*{foo,db},\\(bar\\)}", "a"));
+    t.true(!isMatch("{,.*{foo,db},\\(bar\\)}", "adb"));
+    t.true(!isMatch("{,.*{foo,db},\\(bar\\)}", "a.db"));
+    t.true(isMatch("{,.*{foo,db},\\(bar\\)}", ".db"));
+
+    t.true(!isMatch("{,*.{foo,db},\\(bar\\)}", "a"));
+    t.true(isMatch("{*,*.{foo,db},\\(bar\\)}", "a"));
+    t.true(!isMatch("{,*.{foo,db},\\(bar\\)}", "adb"));
+    t.true(isMatch("{,*.{foo,db},\\(bar\\)}", "a.db"));
+
+    t.true(!isMatch("a/b/**/c{d,e}/**/`xyz.md", "a/b/c/xyz.md"));
+    t.true(!isMatch("a/b/**/c{d,e}/**/xyz.md", "a/b/d/xyz.md"));
+    t.true(isMatch("a/b/**/c{d,e}/**/xyz.md", "a/b/cd/xyz.md"));
+    t.true(isMatch("a/b/**/{c,d,e}/**/xyz.md", "a/b/c/xyz.md"));
+    t.true(isMatch("a/b/**/{c,d,e}/**/xyz.md", "a/b/d/xyz.md"));
+    t.true(isMatch("a/b/**/{c,d,e}/**/xyz.md", "a/b/e/xyz.md"));
+
+    t.true(isMatch("*{a,b}*", "xax"));
+    t.true(isMatch("*{a,b}*", "xxax"));
+    t.true(isMatch("*{a,b}*", "xbx"));
+
+    t.true(isMatch("*{*a,b}", "xba"));
+    t.true(isMatch("*{*a,b}", "xb"));
+
+    t.true(!isMatch("*??", "a"));
+    t.true(!isMatch("*???", "aa"));
+    t.true(isMatch("*???", "aaa"));
+    t.true(!isMatch("*****??", "a"));
+    t.true(!isMatch("*****???", "aa"));
+    t.true(isMatch("*****???", "aaa"));
+
+    t.true(!isMatch("a*?c", "aaa"));
+    t.true(isMatch("a*?c", "aac"));
+    t.true(isMatch("a*?c", "abc"));
+
+    t.true(isMatch("a**?c", "abc"));
+    t.true(!isMatch("a**?c", "abb"));
+    t.true(isMatch("a**?c", "acc"));
+    t.true(isMatch("a*****?c", "abc"));
+
+    t.true(isMatch("*****?", "a"));
+    t.true(isMatch("*****?", "aa"));
+    t.true(isMatch("*****?", "abc"));
+    t.true(isMatch("*****?", "zzz"));
+    t.true(isMatch("*****?", "bbb"));
+    t.true(isMatch("*****?", "aaaa"));
+
+    t.true(!isMatch("*****??", "a"));
+    t.true(isMatch("*****??", "aa"));
+    t.true(isMatch("*****??", "abc"));
+    t.true(isMatch("*****??", "zzz"));
+    t.true(isMatch("*****??", "bbb"));
+    t.true(isMatch("*****??", "aaaa"));
+
+    t.true(!isMatch("?*****??", "a"));
+    t.true(!isMatch("?*****??", "aa"));
+    t.true(isMatch("?*****??", "abc"));
+    t.true(isMatch("?*****??", "zzz"));
+    t.true(isMatch("?*****??", "bbb"));
+    t.true(isMatch("?*****??", "aaaa"));
+
+    t.true(isMatch("?*****?c", "abc"));
+    t.true(!isMatch("?*****?c", "abb"));
+    t.true(!isMatch("?*****?c", "zzz"));
+
+    t.true(isMatch("?***?****c", "abc"));
+    t.true(!isMatch("?***?****c", "bbb"));
+    t.true(!isMatch("?***?****c", "zzz"));
+
+    t.true(isMatch("?***?****?", "abc"));
+    t.true(isMatch("?***?****?", "bbb"));
+    t.true(isMatch("?***?****?", "zzz"));
+
+    t.true(isMatch("?***?****", "abc"));
+    t.true(isMatch("*******c", "abc"));
+    t.true(isMatch("*******?", "abc"));
+    t.true(isMatch("a*cd**?**??k", "abcdecdhjk"));
+    t.true(isMatch("a**?**cd**?**??k", "abcdecdhjk"));
+    t.true(isMatch("a**?**cd**?**??k***", "abcdecdhjk"));
+    t.true(isMatch("a**?**cd**?**??***k", "abcdecdhjk"));
+    t.true(isMatch("a**?**cd**?**??***k**", "abcdecdhjk"));
+    t.true(isMatch("a****c**?**??*****", "abcdecdhjk"));
+
+    t.true(!isMatch("a/?/c/?/*/e.md", "a/b/c/d/e.md"));
+    t.true(isMatch("a/?/c/?/*/e.md", "a/b/c/d/e/e.md"));
+    t.true(isMatch("a/?/c/?/*/e.md", "a/b/c/d/efghijk/e.md"));
+    t.true(isMatch("a/?/**/e.md", "a/b/c/d/efghijk/e.md"));
+    t.true(!isMatch("a/?/e.md", "a/bb/e.md"));
+    t.true(isMatch("a/??/e.md", "a/bb/e.md"));
+    t.true(!isMatch("a/?/**/e.md", "a/bb/e.md"));
+    t.true(isMatch("a/?/**/e.md", "a/b/ccc/e.md"));
+    t.true(isMatch("a/*/?/**/e.md", "a/b/c/d/efghijk/e.md"));
+    t.true(isMatch("a/*/?/**/e.md", "a/b/c/d/efgh.ijk/e.md"));
+    t.true(isMatch("a/*/?/**/e.md", "a/b.bb/c/d/efgh.ijk/e.md"));
+    t.true(isMatch("a/*/?/**/e.md", "a/bbb/c/d/efgh.ijk/e.md"));
+
+    t.true(isMatch("a/*/ab??.md", "a/bbb/abcd.md"));
+    t.true(isMatch("a/bbb/ab??.md", "a/bbb/abcd.md"));
+    t.true(isMatch("a/bbb/ab???md", "a/bbb/abcd.md"));
+  });
+
+  it("fuzz_tests", (t) => {
+    const problem1 =
+      "{*{??*{??**,Uz*zz}w**{*{**a,z***b*[!}w??*azzzzzzzz*!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!z[za,z&zz}w**z*z*}";
+    t.true(!isMatch(problem1, problem1));
+
+    const problem2 =
+      "**** *{*{??*{??***\u{5} *{*{??*{??***\u{5},\0U\0}]*****\u{1},\0***\0,\0\0}w****,\0U\0}]*****\u{1},\0***\0,\0\0}w*****\u{1}***{}*.*\0\0*\0";
+    t.true(!isMatch(problem2, problem2));
+  });
+});

--- a/test/glob.spec.ts
+++ b/test/glob.spec.ts
@@ -29,10 +29,7 @@ const isMatch = (
   _options?: { partial?: boolean },
 ): boolean => matchGlob(glob, path);
 
-const compile = (
-  _glob?: string | string[],
-  _options?: { partial?: boolean },
-): unknown => {
+const compile = (_glob?: string | string[], _options?: { partial?: boolean }): unknown => {
   throw new Error("compile() is not ported");
 };
 

--- a/test/node-glob.spec.ts
+++ b/test/node-glob.spec.ts
@@ -1,0 +1,80 @@
+// Ported from the Node.js core test `test/parallel/test-path-glob.js`:
+//   https://github.com/nodejs/node/blob/main/test/parallel/test-path-glob.js
+//
+// Node's `path.matchesGlob()` delegates to a vendored copy of `minimatch`
+// (`internal/fs/glob` -> `internal/deps/minimatch`). pathe ships its own matcher
+// and normalizes every path to posix, so backslash-separated win32 globs that
+// rely on minimatch treating `\` as a path separator diverge: pathe treats a
+// backslash in the *pattern* as an escape, so `foo\[bcr]ar` becomes a literal
+// `[bcr]` rather than a character class. Those cases are marked `it.todo`.
+//
+// The two win32 cases that Node expects to *not* match (`false`) happen to also
+// not match under pathe, so they are ported as-is.
+import { describe, it, expect } from "vitest";
+
+import { matchesGlob } from "../src/index";
+
+// [path, glob, expected, todo?] — `todo` flags cases where pathe's posix-only
+// matcher diverges from Node's minimatch result.
+type Case = [path: string, glob: string, expected: boolean, todo?: boolean];
+
+const globs: Record<"win32" | "posix", Case[]> = {
+  win32: [
+    ["foo\\bar\\baz", "foo\\[bcr]ar\\baz", true, true], // 'bar' or 'car'
+    ["foo\\bar\\baz", "foo\\[!bcr]ar\\baz", false], // anything except 'bar'/'car'
+    ["foo\\bar\\baz", "foo\\[bc-r]ar\\baz", true, true], // 'bar'/'car' via range
+    ["foo\\bar\\baz", "foo\\*\\!bar\\*\\baz", false], // 'foo'..'baz' but not 'bar'
+    ["foo\\bar1\\baz", "foo\\bar[0-9]\\baz", true, true], // 'bar' + digit
+    ["foo\\bar5\\baz", "foo\\bar[0-9]\\baz", true, true], // 'bar' + digit
+    ["foo\\barx\\baz", "foo\\bar[a-z]\\baz", true, true], // 'bar' + lowercase
+    ["foo\\bar\\baz\\boo", "foo\\[bc-r]ar\\baz\\*", true, true], // 'bar'/'car'
+    ["foo\\bar\\baz", "foo/**", true], // anything under 'foo'
+    ["foo\\bar\\baz", "*", false], // no match
+  ],
+  posix: [
+    ["foo/bar/baz", "foo/[bcr]ar/baz", true], // 'bar' or 'car'
+    ["foo/bar/baz", "foo/[!bcr]ar/baz", false], // anything except 'bar'/'car'
+    ["foo/bar/baz", "foo/[bc-r]ar/baz", true], // 'bar'/'car' via range
+    ["foo/bar/baz", "foo/*/!bar/*/baz", false], // 'foo'..'baz' but not 'bar'
+    ["foo/bar1/baz", "foo/bar[0-9]/baz", true], // 'bar' + digit
+    ["foo/bar5/baz", "foo/bar[0-9]/baz", true], // 'bar' + digit
+    ["foo/barx/baz", "foo/bar[a-z]/baz", true], // 'bar' + lowercase
+    ["foo/bar/baz/boo", "foo/[bc-r]ar/baz/*", true], // 'bar'/'car'
+    ["foo/bar/baz", "foo/**", true], // anything under 'foo'
+    ["foo/bar/baz", "*", false], // no match
+  ],
+};
+
+for (const [platform, cases] of Object.entries(globs)) {
+  describe(`node:path matchesGlob (${platform})`, () => {
+    for (const [path, glob, expected, todo] of cases) {
+      const title = `${JSON.stringify(path)} ${expected ? "matches" : "does not match"} ${JSON.stringify(glob)}`;
+      if (todo) {
+        // Diverges from Node/minimatch — see file header.
+        it.todo(title);
+      } else {
+        it(title, () => {
+          expect(matchesGlob(path, glob)).toBe(expected);
+        });
+      }
+    }
+  });
+}
+
+describe("node:path matchesGlob (non-string input)", () => {
+  // Node throws a TypeError whose message matches /must be of type string/.
+  // pathe also throws a TypeError, but with a different message, so the exact
+  // assertion is marked todo.
+  it.todo("throws for a non-string path");
+  it.todo("throws for a non-string pattern");
+
+  // What pathe actually does today: still throws (just not the Node message).
+  it("throws (some error) for a non-string path", () => {
+    // @ts-expect-error intentionally passing a non-string
+    expect(() => matchesGlob(123, "foo/bar/baz")).toThrow();
+  });
+  it("throws (some error) for a non-string pattern", () => {
+    // @ts-expect-error intentionally passing a non-string
+    expect(() => matchesGlob("foo/bar/baz", 123)).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Removes the `zeptomatch` runtime dependency (and the `esbuild`-based bundling hook it required) by porting the minimum glob-matching logic that `matchesGlob` needs directly into pathe.

**Key insight:** `matchesGlob` never passes zeptomatch's `partial` option. With `partial` always `false`, zeptomatch's heaviest machinery — the generic `graphmatch` graph-to-regex compiler — collapses into a trivial recursive walk. That keeps the port small (`src/_glob.ts`, ~370 lines).

The port contains a faithful, minimal subset of upstream:
- a tiny parser-combinator engine (subset of `grammex`),
- zeptomatch's normalize + parse grammars (globstars, `*`/`?`, classes, `{a,b}` braces, `{1..9}`/`{a..z}` ranges, negation, escaping), transcribed as-is,
- the node-graph → `RegExp` compiler, simplified for the non-partial case and computed leaf-to-root over a BFS node list so pathological globs (e.g. tens of thousands of escapes) don't overflow the stack,
- a compiled-regex cache.

## Attribution

Upstream is MIT (© 2023-present Fabio Spampinato). The full MIT notice + copyright is included at the top of both `src/_glob.ts` and the vendored `test/glob.spec.ts`.

## Tests

zeptomatch's own behavioral test suite (`test/index.js`, 2523 assertions across 28 blocks) is vendored as `test/glob.spec.ts` and runs against the port via a small vitest adapter (`partial`/`memoization` blocks skipped — pathe doesn't use them).

Additionally validated locally against `zeptomatch@2.1.0`:
- 300,000 randomized glob/path cases: **0 mismatches**, identical throw behavior.

### Node.js parity

The upstream Node.js core test for `path.matchesGlob` ([`test/parallel/test-path-glob.js`](https://github.com/nodejs/node/blob/main/test/parallel/test-path-glob.js)) is ported as `test/node-glob.spec.ts`. Node's `path.matchesGlob` delegates to a vendored copy of `minimatch` (`internal/fs/glob` → `internal/deps/minimatch`); this suite checks how close our in-house matcher lands to it.

- **All 10 posix cases pass** — identical results to Node/minimatch.
- **6 win32 cases + 2 type-error cases are marked `it.todo`** as documented, intentional divergences (see below). Everything else passes.

#### Known divergences (documented, `it.todo`)

- **Backslash-separated win32 globs with character classes** (e.g. `foo\[bcr]ar\baz`). pathe normalizes the *path* to posix, but treats `\` in the *pattern* as an escape (so `\[` → a literal `[`), whereas minimatch under `windowsPathsNoEscape: true` treats `\` as a path separator. This is inherent to pathe being posix-only, and matching it would require normalizing backslashes in the pattern too — tricky, since `\` is also the glob escape character. The two win32 cases Node expects to *not* match also don't match here, so they pass as-is.
- **Non-string input.** Both Node and pathe throw a `TypeError`, but pathe's message differs from Node's `/must be of type string/`, so the exact-message assertions are `todo` (a relaxed "throws" assertion is included and passes).

`pnpm test` (lint + vitest --coverage): **457 passed / 8 skipped / 8 todo**; `_glob.ts` at ~98.8% coverage. `pnpm build` produces dist with no external deps.

## Bundle size

Freshly built both branches and measured the shipped `dist`:

| | raw | gzip |
|---|---|---|
| `main` | 25,486 B | 7,830 B |
| this PR | 22,208 B | 6,451 B |
| **Δ** | **−3,278 B (−12.9%)** | **−1,379 B (−17.6%)** |

On `main` the matcher ships as a standalone `_chunks/libs/zeptomatch.mjs` chunk (12,003 B raw). This PR inlines the port into `_chunks/_path.mjs` (which grows ~8.7 KB) and removes that chunk entirely — so the net shipped size drops even though `_path` gets bigger. All other dist files (`index.mjs`, `utils.mjs`, `*.d.mts`) are byte-identical.

## Breaking change?

Marked `refactor!` out of caution since it swaps the matching engine, but behavior is verified equivalent to `zeptomatch@2.1.0` across the full upstream suite and fuzzing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform glob/path matching with brace ranges (including numeric zero-padding), `*`, `**`, `?`, character classes (including negation), and glob-level negations, with consistent path normalization.
* **Refactor**
  * Switched glob matching to the new in-repo `matchGlob` implementation.
* **Tests**
  * Added Vitest coverage mirroring Node-style `path.matchesGlob()` expectations, including platform-specific cases.
* **Build / Chores**
  * Simplified build configuration by removing custom build-time tooling and trimming related dev dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
