### PR TITLE
fix(resolve): preserve UNC prefix (#245)

### DIFF
--- a/src/_path.ts
+++ b/src/_path.ts
@@ -100,6 +100,10 @@ export const resolve: typeof path.resolve = function (...arguments_) {
 
   let resolvedPath = "";
   let resolvedAbsolute = false;
+  // Whether the base (last absolute) segment is a UNC path (e.g. `\\server\share`).
+  // Tracked on the source segment rather than the concatenated `resolvedPath`,
+  // which can start with `//` as an artifact of joining a `/` root.
+  let resolvedUNC = false;
 
   for (let index = arguments_.length - 1; index >= -1 && !resolvedAbsolute; index--) {
     const path = index >= 0 ? arguments_[index] : cwd();
@@ -111,6 +115,7 @@ export const resolve: typeof path.resolve = function (...arguments_) {
 
     resolvedPath = `${path}/${resolvedPath}`;
     resolvedAbsolute = isAbsolute(path);
+    resolvedUNC = _UNC_REGEX.test(path);
   }
 
   // At this point the path should be resolved to a full absolute path, but
@@ -118,6 +123,13 @@ export const resolve: typeof path.resolve = function (...arguments_) {
 
   // Normalize the path
   resolvedPath = normalizeString(resolvedPath, !resolvedAbsolute);
+
+  // Preserve a leading UNC prefix (e.g. `\\server\share`), matching `normalize`
+  // and node's `path.win32.resolve`. `normalizeString` collapses the consecutive
+  // slashes, so it is re-applied here.
+  if (resolvedUNC) {
+    return `//${resolvedPath}`;
+  }
 
   if (resolvedAbsolute && !isAbsolute(resolvedPath)) {
     return `/${resolvedPath}`;

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -398,6 +398,13 @@ runTest("resolve", resolve, [
     String.raw`..\../reports`,
     "C:/Windows/long/reports",
   ],
+
+  // UNC paths (https://github.com/unjs/pathe/issues/245)
+  [String.raw`\\server\share\file`, "//server/share/file"],
+  [String.raw`\\unc-server-name\unc-path`, "//unc-server-name/unc-path"],
+  [String.raw`\\server\share\file`, String.raw`..\path`, "//server/share/path"],
+  [String.raw`\\server\share\file`, "sub", "//server/share/file/sub"],
+  [String.raw`//server/share/file`, "../path", "//server/share/path"],
 ]);
 
 describe("resolve with catastrophic process.cwd() failure", () => {


### PR DESCRIPTION
Fixes #245

## Problem

`resolve()` collapsed the leading `//` of a Windows UNC path down to a single `/`, breaking network paths:

```js
resolve("\\\\unc-server-name\\unc-path")
// was: "/unc-server-name/unc-path"   ❌
// now: "//unc-server-name/unc-path"  ✅
```

`normalizeString()` merges consecutive slashes, so the UNC `//` prefix was lost. `normalize()` already re-applied the prefix via its `isUNCPath` branch, but `resolve()` had no equivalent — so the two disagreed.

## Fix

Track whether the terminating (base) segment is a UNC path and re-apply the `//` prefix after normalization in `resolve()`, mirroring `normalize()`. The flag is tested against the source segment rather than the concatenated `resolvedPath`, which can spuriously start with `//` when joining a `/` root (e.g. `resolve("/", "file.txt")`).

Per pathe's forward-slash convention, UNC paths are represented as `//server/share/...` (matching the existing `normalize()` output and `path.win32.resolve`'s slash count), not Node's back-slash form.

## Tests

Added UNC cases to the `resolve` suite:

```
resolve(\\server\share\file)           →  //server/share/file
resolve(\\server\share\file, ..\path)  →  //server/share/path
resolve(\\server\share\file, sub)      →  //server/share/file/sub
resolve(\\unc-server-name\unc-path)    →  //unc-server-name/unc-path
```

Full suite passes; lint / format / typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path resolution for UNC/network paths so double-slash prefixes are preserved correctly.
  * Fixed resolution behavior when combining UNC paths with relative segments, including `..` and nested subpaths.

* **Tests**
  * Added coverage for UNC path resolution scenarios to verify expected output across multiple cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->