### PR TITLE
fix: compare relative Windows paths case-insensitively

### DIFF
--- a/src/_path.ts
+++ b/src/_path.ts
@@ -241,9 +241,11 @@ export const relative: typeof path.relative = function (from, to) {
     return _to.join("/");
   }
 
+  const compareSegment =
+    _to[0][1] === ":" ? (segment = "") => segment.toLowerCase() : (segment = "") => segment;
   const _fromCopy = [..._from];
   for (const segment of _fromCopy) {
-    if (_to[0] !== segment) {
+    if (compareSegment(_to[0]) !== compareSegment(segment)) {
       break;
     }
     _from.shift();

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -352,6 +352,9 @@ runTest("relative", relative, [
   // Windows
   [String.raw`C:\orandea\test\aaa`, String.raw`C:\orandea\impl\bbb`, "../../impl/bbb"],
   [String.raw`C:\orandea\test\aaa`, String.raw`c:\orandea\impl\bbb`, "../../impl/bbb"],
+  // Windows paths match shared segments case-insensitively.
+  [String.raw`C:\Foo`, String.raw`c:\foo\bar`, "bar"],
+  [String.raw`C:\foo\bar`, String.raw`c:\FOO\baz`, "../baz"],
   ["C:\\", String.raw`C:\foo\bar`, "foo/bar"],
   [String.raw`C:\foo`, "C:\\", ".."],
   [String.raw`C:\foo`, String.raw`d:\bar`, "D:/bar"],


### PR DESCRIPTION
## Summary\n- Fixes #238\n- Compare shared Windows path segments case-insensitively in relative() once both paths are on the same drive\n- Adds regression coverage for mixed-case drive/path segments\n\n## Validation\n- pnpm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows path handling by matching shared path segments without regard to letter casing.
  * Relative paths now resolve correctly when drive-letter paths use different capitalization.

* **Tests**
  * Added coverage for Windows paths with differing segment casing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->