### PR TITLE
fix(resolve): preserve the Windows device path prefix instead of falling through to cwd

### DIFF
--- a/src/_path.ts
+++ b/src/_path.ts
@@ -104,6 +104,11 @@ export const resolve: typeof path.resolve = function (...arguments_) {
   // Tracked on the source segment rather than the concatenated `resolvedPath`,
   // which can start with `//` as an artifact of joining a `/` root.
   let resolvedUNC = false;
+  // Whether the base segment is a device path (e.g. `\\.\c:\temp`). These match
+  // `_UNC_REGEX` but fail `isAbsolute` (its lookahead excludes `//.`), so they
+  // must terminate the loop explicitly and have their `//./` prefix re-applied,
+  // matching the equivalent branch in `normalize`.
+  let resolvedDevice = false;
 
   for (let index = arguments_.length - 1; index >= -1 && !resolvedAbsolute; index--) {
     const path = index >= 0 ? arguments_[index] : cwd();
@@ -114,8 +119,9 @@ export const resolve: typeof path.resolve = function (...arguments_) {
     }
 
     resolvedPath = `${path}/${resolvedPath}`;
-    resolvedAbsolute = isAbsolute(path);
     resolvedUNC = _UNC_REGEX.test(path);
+    resolvedDevice = resolvedUNC && !isAbsolute(path);
+    resolvedAbsolute = isAbsolute(path) || resolvedDevice;
   }
 
   // At this point the path should be resolved to a full absolute path, but
@@ -128,7 +134,12 @@ export const resolve: typeof path.resolve = function (...arguments_) {
   // and node's `path.win32.resolve`. `normalizeString` collapses the consecutive
   // slashes, so it is re-applied here.
   if (resolvedUNC) {
-    return `//${resolvedPath}`;
+    // Match `normalize`'s drive-root rule: a bare drive at the device root
+    // keeps its trailing separator (`//./c:/`, not `//./c:`).
+    if (resolvedDevice && _DRIVE_LETTER_RE.test(resolvedPath)) {
+      resolvedPath += "/";
+    }
+    return resolvedDevice ? `//./${resolvedPath}` : `//${resolvedPath}`;
   }
 
   if (resolvedAbsolute && !isAbsolute(resolvedPath)) {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -405,6 +405,14 @@ runTest("resolve", resolve, [
   [String.raw`\\server\share\file`, String.raw`..\path`, "//server/share/path"],
   [String.raw`\\server\share\file`, "sub", "//server/share/file/sub"],
   [String.raw`//server/share/file`, "../path", "//server/share/path"],
+
+  // Device paths keep their `\\.\` prefix and never fall through to cwd
+  [String.raw`\\.\c:\temp\file`, "//./c:/temp/file"],
+  [String.raw`\\.\c:\temp\file`, String.raw`..\path`, "//./c:/temp/path"],
+  [String.raw`\\.\c:\temp\file`, "sub", "//./c:/temp/file/sub"],
+  ["/ignored", String.raw`\\.\c:\temp\file`, "//./c:/temp/file"],
+  [String.raw`\\.\c:\file`, "..", "//./c:/"],
+  [String.raw`\\?\c:\temp\file`, String.raw`..\path`, "//?/c:/temp/path"],
 ]);
 
 describe("resolve with catastrophic process.cwd() failure", () => {


### PR DESCRIPTION
fixes #253

`resolve()` treated device paths (`\\.\c:\...`) as non-absolute because the `(?!\.)` lookahead in `_IS_ABSOLUTE_RE` excludes them, so the resolution loop fell through to `cwd()`, the device prefix was destroyed, and the working directory leaked into the result. `join` and `normalize` already handle this form correctly via the `//./` re-apply branch in `normalize`, and the verbatim `\\?\` form already survived `resolve`.

The fix mirrors `normalize`'s approach inside `resolve`: a segment that matches `_UNC_REGEX` but fails `isAbsolute` is a device path, it terminates the loop like an absolute segment, and its `//./` prefix is re-applied after `normalizeString`. `_IS_ABSOLUTE_RE` itself is untouched, so `isAbsolute()`'s public behavior does not change.

```
resolve(String.raw`\\.\c:\temp\file`, String.raw`..\path`)
// before: "/<cwd>/c:/temp/path"
// after:  "//./c:/temp/path"   (matches join, normalize, and path.win32)
```

Five regression rows added to the resolve UNC table, including the cwd-independence case (`resolve("/ignored", "\\.\c:\temp\file")`) and a `\\?\` row pinning the already-correct verbatim behavior. Full suite passes (477 tests) and repo lint is clean.

The `..`-above-UNC-root question in #254 is intentionally not touched here, since that direction is a maintainer call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows path resolution for device paths using `\\.\` and `\\?\` prefixes.
  * Preserved the original device-path prefix when resolving and normalizing paths.
  * Prevented device paths from being incorrectly resolved relative to the current working directory, including correct handling of `..` segments and trailing separators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->