### PR TITLE
fix(basename): keep the segment when the suffix would consume it

### DIFF
--- a/src/_path.ts
+++ b/src/_path.ts
@@ -267,7 +267,8 @@ export const format: typeof path.format = function (p) {
 };
 
 export const basename: typeof path.basename = function (p, extension) {
-  const segments = normalizeWindowsPath(p).split("/");
+  const normalizedPath = normalizeWindowsPath(p);
+  const segments = normalizedPath.split("/");
 
   // default to empty string
   let lastSegment = "";
@@ -279,9 +280,19 @@ export const basename: typeof path.basename = function (p, extension) {
     }
   }
 
-  return extension && lastSegment.endsWith(extension)
-    ? lastSegment.slice(0, -extension.length)
-    : lastSegment;
+  if (!extension || !lastSegment.endsWith(extension)) {
+    return lastSegment;
+  }
+
+  // Node only returns an empty string when the suffix is the whole input.
+  // Otherwise a suffix that would consume the entire segment is ignored and
+  // the segment is returned intact, so `basename("/a/index.js", "index.js")`
+  // is `"index.js"` rather than `""`.
+  if (extension === normalizedPath) {
+    return "";
+  }
+
+  return lastSegment.slice(0, -extension.length) || lastSegment;
 };
 
 export const parse: typeof path.parse = function (p) {

--- a/src/_path.ts
+++ b/src/_path.ts
@@ -280,18 +280,22 @@ export const basename: typeof path.basename = function (p, extension) {
     }
   }
 
-  if (!extension || !lastSegment.endsWith(extension)) {
-    return lastSegment;
-  }
-
-  // Node only returns an empty string when the suffix is the whole input.
-  // Otherwise a suffix that would consume the entire segment is ignored and
-  // the segment is returned intact, so `basename("/a/index.js", "index.js")`
-  // is `"index.js"` rather than `""`.
+  // Node only returns an empty string when the suffix is the whole input,
+  // checked against the full path rather than just the last segment, so a
+  // directory-prefixed input (e.g. "/a/b/index.js") with an identical
+  // extension still resolves to "" even though the segment alone ("index.js")
+  // is shorter than the extension and would otherwise never reach this case.
   if (extension === normalizedPath) {
     return "";
   }
 
+  if (!extension || !lastSegment.endsWith(extension)) {
+    return lastSegment;
+  }
+
+  // Otherwise a suffix that would consume the entire segment is ignored and
+  // the segment is returned intact, so `basename("/a/index.js", "index.js")`
+  // is `"index.js"` rather than `""`.
   return lastSegment.slice(0, -extension.length) || lastSegment;
 };
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -103,6 +103,9 @@ runTest("basename", basename, [
   ["/foo/bar.txt", "bar.txt", "bar.txt"],
   ["/a/b/index.js", "index.js", "index.js"],
   ["/foo/.txt", ".txt", ".txt"],
+  // ...unless the extension is the entire (directory-prefixed) input, which
+  // node resolves to "" even though the segment alone is shorter than it.
+  ["/a/b/index.js", "/a/b/index.js", ""],
   ["a/abc", "abc", "abc"],
   ["/abc/", "abc", "abc"],
   ["//abc//", "abc", "abc"],

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -98,6 +98,24 @@ runTest("basename", basename, [
   // Empty string
   ["", ""],
 
+  // A suffix that would consume the whole segment is ignored, matching node.
+  // POSIX
+  ["/foo/bar.txt", "bar.txt", "bar.txt"],
+  ["/a/b/index.js", "index.js", "index.js"],
+  ["/foo/.txt", ".txt", ".txt"],
+  ["a/abc", "abc", "abc"],
+  ["/abc/", "abc", "abc"],
+  ["//abc//", "abc", "abc"],
+  // Windows
+  [String.raw`C:\foo\bar.txt`, "bar.txt", "bar.txt"],
+  [String.raw`C:\foo\.txt`, ".txt", ".txt"],
+  [String.raw`\abc`, "abc", "abc"],
+
+  // ...unless the suffix is the entire input, which node resolves to "".
+  ["abc", "abc", ""],
+  [".txt", ".txt", ""],
+  ["myfile.html", "myfile.html", ""],
+
   // Windows
   [String.raw`C:\temp\myfile.html`, "myfile.html"],
   [String.raw`\temp\myfile.html`, "myfile.html"],


### PR DESCRIPTION
## Problem

`basename(path, suffix)` strips the suffix unconditionally, so a suffix that matches the whole segment leaves an empty string:

```js
import { basename } from "pathe";

basename("/a/b/index.js", "index.js"); // "" — node gives "index.js"
basename("/foo/.txt", ".txt");         // "" — node gives ".txt"
basename("/abc/", "abc");              // "" — node gives "abc"
```

`node:path` only removes the suffix when something would remain. From `lib/path.js`, after the matching loop:

```js
if (start === end) end = firstNonSlashEnd;
```

so the segment is returned intact rather than emptied. The one case where node does return `""` is when the suffix equals the entire input string, handled earlier by `if (suffix === path) return '';`.

This matters for the common `basename(file, extname(file))` idiom, which silently yields `""` for any dotfile-style name such as `.txt`, or whenever the caller passes the full filename as the suffix.

## Fix

Return the segment unchanged when stripping the suffix would empty it, and return `""` only when the suffix is the whole (separator-normalized) input.

## Verification

A differential sweep of 558 `path`/`suffix` combinations against `node:path.posix`, plus the single-argument form for each path:

| | divergences |
|---|---|
| before | 29 |
| after | **13** |

The fix removes 16 and introduces none. The remaining 13 are pre-existing and unrelated to the suffix-consumption rule — they are node's handling of root paths and trailing separators inside the suffix branch:

```js
posix.basename("/", "a");      // node "/"   — pathe ""
posix.basename("/a/", "aaa");  // node "a/"  — pathe "a"
```

Replicating those would undo the deliberate trailing-separator normalization from #180, so I left them alone. Happy to revisit in a separate PR if you would rather match node exactly there too.

Scope note: I compare the suffix against the separator-normalized path, so this change stays clear of the literal-backslash question in #236 / #242.

## Testing

- `npm run test` — 491 passed, 8 skipped, 8 todo
- `npm run test:types` — clean
- New cases added to the existing `runTest("basename", ...)` table, covering both the suffix-consumes-segment and suffix-is-whole-input rules on POSIX and Windows inputs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path basename handling when removing suffixes.
  * Correctly returns an empty result when the suffix matches the entire path.
  * Preserves the final path segment when the suffix is absent, mismatched, or would remove the whole segment.
  * Maintains consistent behavior across POSIX and Windows-style paths.

* **Tests**
  * Added coverage for full-path, full-segment, and partial-segment suffix scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->