### PR TITLE
fix(resolve): preserve Windows device prefix

### DIFF
--- a/src/_path.ts
+++ b/src/_path.ts
@@ -12,6 +12,7 @@ import { matchGlob } from "./_glob";
 import { normalizeWindowsPath } from "./_internal";
 
 const _UNC_REGEX = /^[/\\]{2}/;
+const _DEVICE_PATH_RE = /^[/\\]{2}\.[/\\]/;
 const _IS_ABSOLUTE_RE = /^[/\\](?![/\\])|^[/\\]{2}(?!\.)|^[A-Za-z]:[/\\]/;
 const _DRIVE_LETTER_RE = /^[A-Za-z]:$/;
 const _ROOT_FOLDER_RE = /^\/([A-Za-z]:)?$/;
@@ -104,6 +105,7 @@ export const resolve: typeof path.resolve = function (...arguments_) {
   // Tracked on the source segment rather than the concatenated `resolvedPath`,
   // which can start with `//` as an artifact of joining a `/` root.
   let resolvedUNC = false;
+  let resolvedDevice = false;
 
   for (let index = arguments_.length - 1; index >= -1 && !resolvedAbsolute; index--) {
     const path = index >= 0 ? arguments_[index] : cwd();
@@ -114,7 +116,8 @@ export const resolve: typeof path.resolve = function (...arguments_) {
     }
 
     resolvedPath = `${path}/${resolvedPath}`;
-    resolvedAbsolute = isAbsolute(path);
+    resolvedDevice = _DEVICE_PATH_RE.test(path);
+    resolvedAbsolute = isAbsolute(path) || resolvedDevice;
     resolvedUNC = _UNC_REGEX.test(path);
   }
 
@@ -128,7 +131,7 @@ export const resolve: typeof path.resolve = function (...arguments_) {
   // and node's `path.win32.resolve`. `normalizeString` collapses the consecutive
   // slashes, so it is re-applied here.
   if (resolvedUNC) {
-    return `//${resolvedPath}`;
+    return `//${resolvedDevice ? "./" : ""}${resolvedPath}`;
   }
 
   if (resolvedAbsolute && !isAbsolute(resolvedPath)) {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -405,6 +405,7 @@ runTest("resolve", resolve, [
   [String.raw`\\server\share\file`, String.raw`..\path`, "//server/share/path"],
   [String.raw`\\server\share\file`, "sub", "//server/share/file/sub"],
   [String.raw`//server/share/file`, "../path", "//server/share/path"],
+  [String.raw`\\.\c:\temp\file`, String.raw`..\path`, "//./c:/temp/path"],
 ]);
 
 describe("resolve with catastrophic process.cwd() failure", () => {


### PR DESCRIPTION
`resolve()` now treats `\\.\` device roots as absolute instead of falling through to `cwd()`. It restores `//./` after normalization, matching `join()`, `normalize()`, and Node's `path.win32.resolve()`.

The reproduction from #253 is included in the existing resolve matrix.

Resolves #253.

- `pnpm test`
- `pnpm lint`
- `pnpm test:types`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows path resolution for device namespace paths.
  * Preserved the `//./` prefix when resolving device-based UNC paths.
  * Corrected handling of parent-relative paths combined with Windows device paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->