### PR TITLE
fix(format): match node's dir/root precedence and skip path resolution

### DIFF
--- a/src/_path.ts
+++ b/src/_path.ts
@@ -261,9 +261,19 @@ export const dirname: typeof path.dirname = function (p) {
 };
 
 export const format: typeof path.format = function (p) {
+  // Mirror node's `path.format`: `dir` takes precedence over `root` (`root` is
+  // only a fallback and is ignored when `dir` is set), `base` falls back to
+  // `name` + `ext`, and the pieces are concatenated verbatim. Node does not
+  // resolve `.`/`..` here, so `format(parse(x))` round-trips; the previous
+  // `resolve()` collapsed those segments and dropped a relative `dir` under
+  // `root`. `normalizeWindowsPath` keeps pathe's forward-slash output.
+  const dir = p.dir || p.root;
   const ext = p.ext ? (p.ext.startsWith(".") ? p.ext : `.${p.ext}`) : "";
-  const segments = [p.root, p.dir, p.base ?? (p.name ?? "") + ext].filter(Boolean) as string[];
-  return normalizeWindowsPath(p.root ? resolve(...segments) : segments.join("/"));
+  const base = p.base || `${p.name || ""}${ext}`;
+  if (!dir) {
+    return normalizeWindowsPath(base);
+  }
+  return normalizeWindowsPath(dir === p.root ? dir + base : `${dir}/${base}`);
 };
 
 export const basename: typeof path.basename = function (p, extension) {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -171,6 +171,16 @@ runTest("format", format, [
   [{ ext: ".ext" }, ".ext"],
   [{ dir: "/foo", name: "file" }, "/foo/file"],
 
+  // `dir` overrides `root`: a relative `dir` is not appended onto `root`
+  [{ root: "/r", dir: "rel/dir", base: "f" }, "rel/dir/f"],
+  // Parts are concatenated verbatim, without resolving `.`/`..`, so
+  // `format(parse(x))` round-trips for an unnormalized path
+  [{ root: "/", dir: "/a/../b", base: "c" }, "/a/../b/c"],
+  [{ root: "/", dir: "/a/./b", base: "c" }, "/a/./b/c"],
+  // An empty `base` falls back to `name` + `ext` (matching node's `||`)
+  [{ root: "/", dir: "/a", name: "x", ext: ".js", base: "" }, "/a/x.js"],
+  [{ name: "x", ext: ".js", base: "" }, "x.js"],
+
   // Windows
   [{ name: "file", base: "file.txt" }, "file.txt"],
   [{ dir: String.raw`C:\path\dir`, base: "file.txt" }, "C:/path/dir/file.txt"],


### PR DESCRIPTION
I ran into this using `format(parse(p))` to swap out a basename, and noticed the result came back normalized even though I never asked for that.

`format()` currently assembles the path with `resolve()`, which resolves `.` and `..`. node's `path.format()` leaves those segments alone and just concatenates the pieces, so `format(parse(x))` should round-trip. Today it doesn't:

```js
import { format, parse } from "pathe";

format(parse("/a/../b/c")); // "/b/c",  node gives "/a/../b/c"
```

While I was in there I lined up two smaller differences with node in the same function:

- When both `root` and `dir` are set, node ignores `root` and uses `dir`. pathe fed both into `resolve()`, so a relative `dir` got appended onto `root`:

  ```js
  format({ root: "/r", dir: "rel/dir", base: "f" }); // "/r/rel/dir/f",  node gives "rel/dir/f"
  ```

- `base` was read with `??`, so an explicit empty string didn't fall back to `name` + `ext` the way node's `||` does:

  ```js
  format({ dir: "/a", name: "x", ext: ".js", base: "" }); // "/a",  node gives "/a/x.js"
  ```

The fix rebuilds the string the way node's posix `format` does: `dir` takes precedence over `root`, `base` falls back to `name` + `ext`, and the parts are joined verbatim with no resolution. `normalizeWindowsPath()` still runs, so output stays forward-slashed and drive letters keep normalizing.

I compared the new output against `node:path`'s posix `format` across a large batch of generated path objects and they now agree everywhere. The existing `format` tests are untouched and still pass; I added a few cases covering the three points above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path formatting to match Node.js behavior.
  * Correctly prioritizes directory and base components when constructing paths.
  * Preserves relative `.` and `..` segments without resolving them.

* **Tests**
  * Added coverage for directory precedence, relative path preservation, and fallback name/extension handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->