### PR TITLE
feat: safePath and safeName utils

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -132,3 +132,38 @@ function hasTrailingSlash(path = "/") {
   const lastChar = path[path.length - 1];
   return lastChar === "/" || lastChar === "\\";
 }
+
+const WindowsInvalidNameCharsRe = /[\x00-\x1F<>:"/\\|?*]/g;
+
+/**
+ * Sanitizes a name to be valid on Windows and Unix by replacing invalid characters with their percent-encoded equivalents.
+ *
+ * @param name - The name to sanitize.
+ * @returns the sanitized name.
+ */
+export function safeName(name: string): string {
+  return name.replace(
+    WindowsInvalidNameCharsRe,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase().padStart(2, "0")}`,
+  );
+}
+
+/**
+ * Sanitizes a path to be valid on Windows and Unix by applying `safeName` to each segment.
+ *
+ * @param path - The path to sanitize.
+ * @returns the sanitized path.
+ */
+export function safePath(path: string): string {
+  const _path = normalizeWindowsPath(path);
+  const segments = _path.split("/");
+  return segments
+    .map((seg, index) => {
+      // Preserve Windows drive letter
+      if (index === 0 && /^[a-zA-Z]:$/.test(seg)) {
+        return seg;
+      }
+      return safeName(seg);
+    })
+    .join("/");
+}

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { normalizeAliases, filename, resolveAlias, reverseResolveAlias } from "../src/utils";
+import { normalizeAliases, filename, resolveAlias, reverseResolveAlias, safeName, safePath } from "../src/utils";
 
 describe("alias", () => {
   const _aliases = {
@@ -122,4 +122,28 @@ describe("filename", () => {
       expect(filename(file)).toEqual(files[file as keyof typeof files]);
     });
   }
+});
+
+describe("safeName", () => {
+  it("replaces invalid characters with their percent-encoded equivalents", () => {
+    expect(safeName("foo:bar")).toBe("foo%3Abar");
+    expect(safeName('foo"bar')).toBe("foo%22bar");
+    expect(safeName("foo<bar>")).toBe("foo%3Cbar%3E");
+    expect(safeName("foo/bar")).toBe("foo%2Fbar");
+    expect(safeName("foo\\bar")).toBe("foo%5Cbar");
+    expect(safeName("foo|bar")).toBe("foo%7Cbar");
+    expect(safeName("foo?bar")).toBe("foo%3Fbar");
+    expect(safeName("foo*bar")).toBe("foo%2Abar");
+    expect(safeName("foo\x00bar")).toBe("foo%00bar");
+  });
+});
+
+describe("safePath", () => {
+  it("replaces invalid characters in each segment of the path", () => {
+    expect(safePath("C:/foo:bar/baz")).toBe("C:/foo%3Abar/baz");
+    expect(safePath("C:\\foo<bar>\\baz")).toBe("C:/foo%3Cbar%3E/baz");
+    expect(safePath("/foo/bar:baz/qux*")).toBe("/foo/bar%3Abaz/qux%2A");
+    expect(safePath("file.txt")).toBe("file.txt");
+    expect(safePath("//server/share/file?name")).toBe("//server/share/file%3Fname");
+  });
 });


### PR DESCRIPTION
Fixes #47. Added `safeName` and `safePath` exports in `pathe/utils` replacing Windows invalid characters with their percent-encoded equivalents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safer handling for filenames and paths by encoding invalid characters.
  * Normalized path separators while preserving valid paths and Windows drive letters.

* **Tests**
  * Added coverage for filename encoding and path sanitization across supported path formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->