### PR TITLE
fix: treat `//.a` and `//..` as absolute paths

### DIFF
--- a/src/_path.ts
+++ b/src/_path.ts
@@ -12,7 +12,14 @@ import { matchGlob } from "./_glob";
 import { normalizeWindowsPath } from "./_internal";
 
 const _UNC_REGEX = /^[/\\]{2}/;
-const _IS_ABSOLUTE_RE = /^[/\\](?![/\\])|^[/\\]{2}(?!\.)|^[A-Za-z]:[/\\]/;
+/**
+ * A path is absolute when it starts with a separator or a drive letter.
+ *
+ * The `//` alternative excludes the Windows device namespace prefix `\\.\`,
+ * which `normalize` reconstructs separately. That prefix requires the dot to be
+ * followed by a separator, so `//.a` and `//..` are ordinary absolute paths.
+ */
+const _IS_ABSOLUTE_RE = /^[/\\](?![/\\])|^[/\\]{2}(?!\.[/\\])|^[A-Za-z]:[/\\]/;
 const _DRIVE_LETTER_RE = /^[A-Za-z]:$/;
 const _ROOT_FOLDER_RE = /^\/([A-Za-z]:)?$/;
 const _EXTNAME_RE = /.(\.[^./]+|\.)$/;

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -40,6 +40,9 @@ runTest("isAbsolute", isAbsolute, {
   "/baz/..": true,
   "quax/": false,
   ".": false,
+  "//.a": true,
+  "//..": true,
+  "//.": true,
 
   // Windows
   "C:": false,
@@ -200,6 +203,10 @@ runTest("join", join, [
   [String.raw`\\.\c:\temp\file`, String.raw`..\path`, "//./c:/temp/path"],
   [String.raw`\\server/share/file`, "../path", "//server/share/path"],
   [String.raw`//server/share/file`, "../path", "//server/share/path"],
+  // A dot after `//` only starts a device path when a separator follows
+  ["//", ".a", "//.a"],
+  ["//", "..", "/"],
+  ["//", ".", "/"],
 ]);
 
 runTest("normalize", normalize, {
@@ -216,6 +223,9 @@ runTest("normalize", normalize, {
   "./../dep/": "../dep/",
   "path//dep\\": "path/dep/",
   "/foo/bar//baz/asdf/quux/..": "/foo/bar/baz/asdf",
+  "//.a": "//.a",
+  "//..": "/",
+  "//.": "/",
 
   // Windows
   "C:\\": "C:/",


### PR DESCRIPTION
### Problem

`_IS_ABSOLUTE_RE` treats a path as absolute unless a dot follows the leading `//`:

```js
/^[/\\](?![/\\])|^[/\\]{2}(?!\.)|^[A-Za-z]:[/\\]/
```

The `(?!\.)` is there so the Windows device prefix `\\.\` falls through to the branch in `normalize` that reconstructs it as `//./`. But a device prefix requires a separator after the dot, so the guard also catches ordinary absolute paths whose first segment merely *starts* with a dot.

`isAbsolute('//.a')` is therefore `false`, and `normalize` takes the device branch and injects a `./` segment. When nothing is left after normalization it returns a relative path, dropping the root:

```js
normalize('//.a')  // '//./.a'   expected '//.a'
normalize('//..')  // '//./..'   expected '/'
normalize('//.')   // '.'        expected '/'
```

`join` builds on `normalize`, so it inherits all three, and joining onto `//` can return a relative path:

```js
join('//', '.a')  // '//./.a'  expected '//.a'
join('//', '..')  // '//./..'  expected '/'
join('//', '.')   // '.'       expected '/'
```

Node agrees that all of these inputs are absolute, in both flavors:

```js
posix.isAbsolute('//.a')  // true      win32.isAbsolute('//.a')  // true
posix.normalize('//.a')   // '/.a'     win32.normalize('//.a')   // '\\.a'
posix.normalize('//..')   // '/'       win32.normalize('//..')   // '\\'
```

Note the win32 column: Node keeps the device prefix for `//./x` and `//./C:/x`, but not for `//.a`, `//..` or `//.`. The rule really is "dot followed by a separator".

### Fix

Require that separator in the lookahead:

```diff
-const _IS_ABSOLUTE_RE = /^[/\\](?![/\\])|^[/\\]{2}(?!\.)|^[A-Za-z]:[/\\]/;
+const _IS_ABSOLUTE_RE = /^[/\\](?![/\\])|^[/\\]{2}(?!\.[/\\])|^[A-Za-z]:[/\\]/;
```

After the change, keeping pathe's `//` preservation:

```js
normalize('//.a')           // '//.a'
normalize('//..')           // '/'
normalize('//.')            // '/'
normalize('//./foo/bar')    // '//./foo/bar'     device path, unchanged
normalize('//server/share') // '//server/share'  UNC, unchanged
```

The existing device-path and UNC cases in `index.spec.ts` (`\\.\c:\temp\file\..\path`, `\\.\foo\bar`, `\\server\share\...`) still pass unmodified, so they act as the regression guard for the prefix that the lookahead is meant to protect.

### Scope

This is deliberately limited to the misclassification. Device paths still route through the non-absolute branch so `normalize` can rebuild the `//./` prefix, which means `isAbsolute('//./C:/x')` remains `false` where Node returns `true`. Changing that would mean reworking how `normalize` reconstructs the prefix, which seemed out of scope for a fix this size. Happy to follow up if you would like it addressed.

### Testing

Added cases to the existing `isAbsolute`, `normalize` and `join` tables. Full suite passes (485 tests). Reverting `src/_path.ts` while keeping the new tests fails 18 assertions, so they cover the change rather than restating current behavior.

Found by differentially testing pathe's POSIX-shaped inputs against `node:path.posix`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved absolute-path detection for POSIX-style paths beginning with `//`.
  - Paths such as `//.a` and `//..` are now correctly recognized as absolute.
  - Corrected normalization behavior so `//..` and `//.` resolve to `/`.
  - Preserved appropriate path behavior for special Windows device namespace prefixes.

- **Tests**
  - Added coverage for absolute-path detection, joining, and normalization involving `//`, `.`, `..`, and `.a` path segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->