### PR TITLE
fix(basename): do not let the suffix consume the whole segment

### DIFF
--- a/src/_path.ts
+++ b/src/_path.ts
@@ -267,7 +267,15 @@ export const format: typeof path.format = function (p) {
 };
 
 export const basename: typeof path.basename = function (p, extension) {
-  const segments = normalizeWindowsPath(p).split("/");
+  const _p = normalizeWindowsPath(p);
+
+  // Node only returns an empty string when the whole path *is* the extension;
+  // otherwise the suffix is never allowed to consume the entire segment.
+  if (extension && _p === extension) {
+    return "";
+  }
+
+  const segments = _p.split("/");
 
   // default to empty string
   let lastSegment = "";
@@ -279,7 +287,7 @@ export const basename: typeof path.basename = function (p, extension) {
     }
   }
 
-  return extension && lastSegment.endsWith(extension)
+  return extension && lastSegment.length > extension.length && lastSegment.endsWith(extension)
     ? lastSegment.slice(0, -extension.length)
     : lastSegment;
 };

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -98,6 +98,22 @@ runTest("basename", basename, [
   // Empty string
   ["", ""],
 
+  // The suffix never consumes a whole segment (matches node)
+  // https://nodejs.org/api/path.html#pathbasenamepath-suffix
+  ["a/b", "b", "b"],
+  ["/b", "b", "b"],
+  ["./a", "a", "a"],
+  ["dir/index.js", "index.js", "index.js"],
+  ["abc/", "abc", "abc"],
+  ["a//", "a", "a"],
+  ["a/b/", "b", "b"],
+  // ...unless the path itself is exactly the suffix
+  ["abc", "abc", ""],
+  [".a", ".a", ""],
+  // A longer segment is still stripped
+  ["a/bb", "b", "b"],
+  ["dir/myfile.html", ".html", "myfile"],
+
   // Windows
   [String.raw`C:\temp\myfile.html`, "myfile.html"],
   [String.raw`\temp\myfile.html`, "myfile.html"],


### PR DESCRIPTION
`basename(path, suffix)` diverges from `node:path` whenever the suffix is the entire base name.

```js
import { basename } from "pathe";
import { basename as nodeBasename } from "node:path/posix";

basename("dir/index.js", "index.js"); // ""  — node: "index.js"
basename("a/b", "b");                 // ""  — node: "b"
basename("./a", "a");                 // ""  — node: "a"
basename("abc/", "abc");              // ""  — node: "abc"
nodeBasename("dir/index.js", "index.js"); // "index.js"
```

## Root cause

The suffix is stripped whenever the segment merely *ends with* it:

```ts
return extension && lastSegment.endsWith(extension)
  ? lastSegment.slice(0, -extension.length)
  : lastSegment;
```

When the suffix equals the whole segment, `slice(0, -len)` empties it. Node's implementation only enters the strip path when the base name is **strictly longer** than the suffix, so the returned base name is never empty — the one exception being when the input path *is* the suffix (`basename("abc", "abc") === ""`, which node reaches through a different branch and pathe already matched).

This matters for the common "drop a known file name" call shape (`basename(p, "index.js")`, `basename(p, "package.json")`), where pathe silently returns an empty string.

## Change

- Return `""` early when the normalized path equals the suffix (preserving node's one empty-result case).
- Otherwise require `lastSegment.length > extension.length` before stripping.

## Validation

- `pnpm test` — 489 passed, 8 skipped, 8 todo (was 467 passed before the new cases).
- `pnpm lint` — clean (oxlint + oxfmt).
- Differential check against `node:path/posix` over 627 `(path, suffix)` combinations built from 33 paths × 19 suffixes: **43 mismatches before, 30 after**. Every mismatch this fixes is a suffix case; the 30 remaining are pre-existing and unrelated (they are all `basename("///", …)` and `basename("./", "..")`, which stem from how pathe collapses separators, not from suffix handling).

22 regression cases were added to the existing `runTest("basename", ...)` table, covering both the "suffix must not empty the segment" rule and the `path === suffix` exception.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `basename` handling for exact extension matches and paths with trailing separators.
  - Prevented extensions from incorrectly consuming an entire filename segment.
  - Aligned POSIX path behavior more closely with Node.js.

- **Tests**
  - Added coverage for suffix handling across path segments, trailing separators, exact matches, and longer filenames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->